### PR TITLE
(old) feat: distribute desktop apps in GitHub Releases with Conveyor

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -116,11 +116,13 @@ jobs:
           releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
           mappingFile: android/app/build/outputs/mapping/release/mapping.txt
 
-      - name: Assemble desktop tar and zip
+      - name: Create jars
         if: always()
-        run: ./gradlew desktop:app:assembleDist
+        run: ./gradlew jar
 
-      - uses: hydraulic-software/conveyor/actions/build@v14.2
+      - name: Create desktop distributions
+        uses: hydraulic-software/conveyor/actions/build@v14.2
+        if: always()
         with:
           signing_key: ${{ secrets.SIGNING_KEY }}
           agree_to_license: 1

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -99,36 +99,37 @@ jobs:
       - name: Assemble apk, bundle aab
         run: ./gradlew assembleRelease bundleRelease
 
-      - name: Authenticate to Google Cloud
-        id: auth
-        uses: google-github-actions/auth@v2.1.3
-        with:
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.SERVICE_ACCOUNT }}
-
-      - name: Publish build to Google Play's beta track
-        id: publish_play_store
-        uses: r0adkll/upload-google-play@v1.1.3
-        with:
-          serviceAccountJson: ${{ steps.auth.outputs.credentials_file_path }}
-          packageName: io.github.lydavid.musicsearch
-          track: beta
-          releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
-          mappingFile: android/app/build/outputs/mapping/release/mapping.txt
+# TODO: uncomment
+#      - name: Authenticate to Google Cloud
+#        id: auth
+#        uses: google-github-actions/auth@v2.1.3
+#        with:
+#          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+#          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+#
+#      - name: Publish build to Google Play's beta track
+#        id: publish_play_store
+#        uses: r0adkll/upload-google-play@v1.1.3
+#        with:
+#          serviceAccountJson: ${{ steps.auth.outputs.credentials_file_path }}
+#          packageName: io.github.lydavid.musicsearch
+#          track: beta
+#          releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
+#          mappingFile: android/app/build/outputs/mapping/release/mapping.txt
 
       - name: Create jars
         if: always()
         run: ./gradlew jar
 
       - name: Create desktop distributions
-        uses: hydraulic-software/conveyor/actions/build@v14.2
+        uses: hydraulic-software/conveyor/actions/build@v14.3
         if: always()
         with:
           signing_key: ${{ secrets.SIGNING_KEY }}
           agree_to_license: 1
-          command: make copied-site
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          command: make site
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.PAT }}
 
       - name: Commit version code bump
         uses: stefanzweifel/git-auto-commit-action@v5.0.1
@@ -140,6 +141,6 @@ jobs:
 
       - name: Publish to GitHub
         if: always()
-        run: npx semantic-release
+        run: npx semantic-release --dry-run # TODO: remove --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -6,6 +6,7 @@ name: Publish beta build
 # eg. If only chores were committed, then there would be no new GitHub release.
 # Google Play allows us to reuse versionName, so it isn't a problem for our releases to be out of sync.
 on:
+  push: # TODO: remove
   schedule:
     - cron: '42 7 * * *'
   workflow_dispatch:
@@ -118,6 +119,12 @@ jobs:
       - name: Assemble desktop tar and zip
         if: always()
         run: ./gradlew desktop:app:assembleDist
+
+      - uses: hydraulic-software/conveyor/actions/build@v14.2
+        with:
+          signing_key: ${{ secrets.SIGNING_KEY }}
+          agree_to_license: 1
+          command: make copied-site
 
       - name: Merge with origin in case changes have been pushed since job start
         if: always()

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -127,12 +127,8 @@ jobs:
           signing_key: ${{ secrets.SIGNING_KEY }}
           agree_to_license: 1
           command: make copied-site
-
-      - name: Merge with origin in case changes have been pushed since job start
-        if: always()
-        run: |
-          git fetch
-          git merge -X ours origin/beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
 
       - name: Commit version code bump
         uses: stefanzweifel/git-auto-commit-action@v5.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ music_search.db
 
 # Xcode
 xcuserdata/
+
+# Conveyor desktop distribution
+output/

--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,8 @@
 {
   "branches": [
     "master",
-    {"name": "beta", "prerelease": true}
+    {"name": "beta", "prerelease": true},
+    {"name": "dl/conveyor-distribute-desktop", "prerelease": true},
   ],
   "repositoryUrl": "https://github.com/lydavid/MusicSearch",
   "debug": "false",
@@ -14,8 +15,7 @@
       {
         "assets": [
             "android/app/build/outputs/apk/release/*.apk",
-            "desktop/app/build/distributions/*.tar",
-            "desktop/app/build/distributions/*.zip"
+            "output/*"
         ],
         "successComment": false,
         "failTitle": false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,8 +80,14 @@ subprojects {
 }
 
 // Debugging info copied from https://github.com/JFormDesigner/markdown-writer-fx/blob/62bab275f8b32ced1aae80b64ff3389c7c4f5e8c/build.gradle.kts#L30
-println("Java ${System.getProperty("java.version")} ${System.getProperty("java.vendor")}")
-println("Gradle ${gradle.gradleVersion} at ${gradle.gradleHomeDir}")
+project.logger.log(
+    LogLevel.DEBUG,
+    "Java ${System.getProperty("java.version")} ${System.getProperty("java.vendor")}",
+)
+project.logger.log(
+    LogLevel.DEBUG,
+    "Gradle ${gradle.gradleVersion} at ${gradle.gradleHomeDir}",
+)
 
 // Android Studio highlighting in standalone gradle.kts scripts seems to be broken:
 // https://issuetracker.google.com/issues/293048764

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -13,12 +13,12 @@ app {
   license = Apache 2
 
   // Upload to GitHub Releases and make download page available via sites.
-  site {
-    github {
-      oauth-token = ${env.GITHUB_TOKEN}
-      pages-branch = "gh-pages"
-    }
-  }
+  // site {
+  //  github {
+  //    oauth-token = ${env.GITHUB_TOKEN}
+  //    pages-branch = "gh-pages"
+  //  }
+  // }
 
   // Make sure skiko and other native libs are extracted and placed in the app directory as appropriate.
   // See https://hydraulic.software/blog/11-in-jar-signing.html

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -1,0 +1,30 @@
+// Import configuration from Gradle, this task is added by the Conveyor plugin.
+include required("#!./gradlew -q desktop:app:printConveyorConfig")
+
+app {
+  display-name = "MusicSearch"
+  fsname = "musicsearch"
+  vendor = "lydavid"
+  contact-email = "dvdly.apps@gmail.com"
+  icons = "assets/logo.svg"
+
+  // When source code is released under an open source license, Conveyor is free.
+  vcs-url = github.com/lydavid/MusicSearch
+  license = Apache 2
+
+  // Upload to GitHub Releases and make download page available via sites.
+  site {
+    github {
+      oauth-token = ${env.GITHUB_TOKEN}
+      pages-branch = "gh-pages"
+    }
+  }
+
+  // Make sure skiko and other native libs are extracted and placed in the app directory as appropriate.
+  // See https://hydraulic.software/blog/11-in-jar-signing.html
+  jvm.extract-native-libraries = true
+}
+
+// This line is added automatically when a new project is created. It
+// allows Conveyor to change whilst preserving backwards compatibility.
+conveyor.compatibility-level = 12

--- a/desktop/app/build.gradle.kts
+++ b/desktop/app/build.gradle.kts
@@ -3,14 +3,17 @@ plugins {
     id("ly.david.musicsearch.compose.multiplatform")
     application
     alias(libs.plugins.aboutlibraries)
+    id("dev.hydraulic.conveyor") version "1.5"
 }
-
-group = "ly.david.musicsearch"
-version = project.properties["VERSION_NAME"] as String
 
 application {
     mainClass.set("MainKt")
 }
+
+group = "io.github.lydavid.musicsearch"
+version = "1.2.0" // project.properties["VERSION_NAME"] as String
+// TODO: transform VERSION_NAME to an appropriate version for other platforms
+//  need to merge -beta.13 into the patch version
 
 aboutLibraries {
     excludeFields = arrayOf("generated")
@@ -25,15 +28,25 @@ dependencies {
     implementation(projects.ui.core)
     implementation(projects.core.preferences)
 
-    // gradle desktop:app:projectHealth falsely reports this as unused
-    implementation(compose.desktop.currentOs)
+    linuxAmd64(compose.desktop.linux_x64)
+    macAmd64(compose.desktop.macos_x64)
+    macAarch64(compose.desktop.macos_arm64)
+    windowsAmd64(compose.desktop.windows_x64)
 
     implementation(libs.circuit.foundation)
     implementation(libs.koin.core)
 }
 
-distributions {
-    main {
-        distributionBaseName = "MusicSearch"
+// region Work around temporary Compose bugs.
+configurations.all {
+    attributes {
+        // https://github.com/JetBrains/compose-jb/issues/1404#issuecomment-1146894731
+        attribute(Attribute.of("ui", String::class.java), "awt")
+    }
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(19))
     }
 }

--- a/desktop/app/build.gradle.kts
+++ b/desktop/app/build.gradle.kts
@@ -11,9 +11,7 @@ application {
 }
 
 group = "io.github.lydavid.musicsearch"
-version = "1.2.0" // project.properties["VERSION_NAME"] as String
-// TODO: transform VERSION_NAME to an appropriate version for other platforms
-//  need to merge -beta.13 into the patch version
+version = getDesktopVersion()
 
 aboutLibraries {
     excludeFields = arrayOf("generated")
@@ -41,7 +39,13 @@ dependencies {
 configurations.all {
     attributes {
         // https://github.com/JetBrains/compose-jb/issues/1404#issuecomment-1146894731
-        attribute(Attribute.of("ui", String::class.java), "awt")
+        attribute(
+            Attribute.of(
+                "ui",
+                String::class.java,
+            ),
+            "awt",
+        )
     }
 }
 
@@ -49,4 +53,23 @@ java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(19))
     }
+}
+
+/**
+ * Transform a version name to the format MAJOR.MINOR.PATCH, where each part is a number.
+ *
+ * e.g. 1.2.1-beta.14 to 1.2.114
+ */
+fun getDesktopVersion(): String {
+    var versionName = project.properties["VERSION_NAME"] as String
+    val parts = versionName.split("-")
+    val versionPart = parts.first()
+    val betaPart = parts.last()
+    if (versionPart != betaPart) {
+        val splitVersion = versionPart.split(".")
+        val betaNum = betaPart.split(".").last().toInt()
+        val modifiedPatch = splitVersion.last().toInt() * 100 + betaNum
+        versionName = "${splitVersion[0]}.${splitVersion[1]}.$modifiedPatch"
+    }
+    return versionName
 }


### PR DESCRIPTION
See https://github.com/lydavid/MusicSearch/pull/952 instead. 
semantic-release could not make a pre-release with the branch `dl/conveyor-distribute-desktop`