### PR TITLE
chore: run ios tests (repeat common tests on macos)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,3 +75,15 @@ jobs:
           commit_author: musicsearch-gha-helper[bot] <173635759+musicsearch-gha-helper[bot]@users.noreply.github.com>
           disable_globbing: true
           file_pattern: '*/*.png'
+
+  assemble:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - id: setup
+        uses: ./.github/actions/setup
+
+      - name: Assemble
+        run: ./gradlew assemble

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,7 +76,7 @@ jobs:
           disable_globbing: true
           file_pattern: '*/*.png'
 
-  assemble:
+  ios-checks:
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -85,5 +85,4 @@ jobs:
       - id: setup
         uses: ./.github/actions/setup
 
-      - name: Assemble
-        run: ./gradlew iosSimulatorArm64Test
+      - run: ./gradlew iosSimulatorArm64Test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,4 +86,4 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Assemble
-        run: ./gradlew assemble
+        run: ./gradlew iosSimulatorArm64Test


### PR DESCRIPTION
References:
- https://youtrack.jetbrains.com/issue/KT-70700/Gradle-8.10-The-value-for-task-commonizeNativeDistribution-property-kotlinNativeBundleBuildService-cannot-be-changed-any-further 
- https://github.com/eygraber/compose-placeholder/blob/master/.github/workflows/pr.yml#L17-L33