### PR TITLE
fix: use a view for entities with cover arts

### DIFF
--- a/data/coverart/build.gradle.kts
+++ b/data/coverart/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
             dependencies {
                 implementation(projects.shared.domain)
                 implementation(projects.core.logging.api)
+                implementation(projects.core.coroutines)
                 implementation(libs.koin.core)
                 implementation(project.dependencies.platform(libs.ktor.bom))
                 implementation(libs.ktor.client.core)
@@ -18,7 +19,14 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
+                implementation(projects.testData)
+                implementation(projects.data.musicbrainz)
+                implementation(projects.data.database)
                 implementation(libs.kotlin.test)
+                implementation(libs.koin.test)
+                implementation(libs.junit)
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.androidx.paging.testing)
             }
         }
     }

--- a/data/coverart/src/commonMain/kotlin/ly/david/musicsearch/data/coverart/ImageMetadataRepositoryImpl.kt
+++ b/data/coverart/src/commonMain/kotlin/ly/david/musicsearch/data/coverart/ImageMetadataRepositoryImpl.kt
@@ -17,7 +17,7 @@ import ly.david.musicsearch.shared.domain.error.HandledException
 import ly.david.musicsearch.shared.domain.image.ImageMetadata
 import ly.david.musicsearch.shared.domain.image.ImageUrlDao
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
-import ly.david.musicsearch.shared.domain.release.ImageMetadataRepository
+import ly.david.musicsearch.shared.domain.image.ImageMetadataRepository
 
 internal class ImageMetadataRepositoryImpl(
     private val coverArtArchiveApi: CoverArtArchiveApi,

--- a/data/coverart/src/commonMain/kotlin/ly/david/musicsearch/data/coverart/api/CoverArtsResponse.kt
+++ b/data/coverart/src/commonMain/kotlin/ly/david/musicsearch/data/coverart/api/CoverArtsResponse.kt
@@ -67,12 +67,3 @@ private fun CoverArtUrls.getUrl(): String? {
     return thumbnailsUrls?.resolution1200Url ?: thumbnailsUrls?.resolution500Url ?: thumbnailsUrls?.large
         ?: thumbnailsUrls?.resolution250Url ?: thumbnailsUrls?.small
 }
-
-fun CoverArtsResponse.getFrontThumbnailCoverArtUrl(): String? {
-    // Note: MB doesn't fall back to any non-front covers
-    return coverArtUrls.firstOrNull { it.front }?.getThumbnailUrl()
-}
-
-fun CoverArtsResponse.getFrontCoverArtUrl(): String? {
-    return coverArtUrls.firstOrNull { it.front }?.thumbnailsUrls?.resolution1200Url
-}

--- a/data/coverart/src/commonMain/kotlin/ly/david/musicsearch/data/coverart/di/CoverArtModule.kt
+++ b/data/coverart/src/commonMain/kotlin/ly/david/musicsearch/data/coverart/di/CoverArtModule.kt
@@ -3,7 +3,7 @@ package ly.david.musicsearch.data.coverart.di
 import ly.david.musicsearch.data.coverart.ImageMetadataRepositoryImpl
 import ly.david.musicsearch.data.coverart.api.CoverArtArchiveApi
 import ly.david.musicsearch.data.coverart.api.CoverArtArchiveApiImpl
-import ly.david.musicsearch.shared.domain.release.ImageMetadataRepository
+import ly.david.musicsearch.shared.domain.image.ImageMetadataRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module

--- a/data/coverart/src/jvmTest/kotlin/ly/david/musicsearch/data/coverart/ImageMetadataRepositoryImplTest.kt
+++ b/data/coverart/src/jvmTest/kotlin/ly/david/musicsearch/data/coverart/ImageMetadataRepositoryImplTest.kt
@@ -1,0 +1,641 @@
+package ly.david.musicsearch.data.coverart
+
+import androidx.paging.testing.asSnapshot
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import ly.david.data.test.KoinTestRule
+import ly.david.data.test.api.NoOpCoverArtArchiveApi
+import ly.david.musicsearch.core.coroutines.CoroutineDispatchers
+import ly.david.musicsearch.core.logging.Logger
+import ly.david.musicsearch.data.coverart.api.CoverArtUrls
+import ly.david.musicsearch.data.coverart.api.CoverArtsResponse
+import ly.david.musicsearch.data.coverart.api.ThumbnailsUrls
+import ly.david.musicsearch.data.database.dao.EventDao
+import ly.david.musicsearch.data.database.dao.ReleaseDao
+import ly.david.musicsearch.data.database.dao.ReleaseGroupDao
+import ly.david.musicsearch.data.musicbrainz.models.core.EventMusicBrainzModel
+import ly.david.musicsearch.data.musicbrainz.models.core.ReleaseGroupMusicBrainzModel
+import ly.david.musicsearch.data.musicbrainz.models.core.ReleaseMusicBrainzModel
+import ly.david.musicsearch.shared.domain.coverarts.CoverArtsSortOption
+import ly.david.musicsearch.shared.domain.image.ImageMetadata
+import ly.david.musicsearch.shared.domain.image.ImageUrlDao
+import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
+import ly.david.musicsearch.shared.domain.network.resourceUri
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.koin.test.KoinTest
+import org.koin.test.inject
+
+class ImageMetadataRepositoryImplTest : KoinTest {
+
+    @get:Rule(order = 0)
+    val koinTestRule = KoinTestRule()
+
+    private val imageUrlDao: ImageUrlDao by inject()
+    private val coroutineDispatchers: CoroutineDispatchers by inject()
+    private val eventDao: EventDao by inject()
+    private val releaseDao: ReleaseDao by inject()
+    private val releaseGroupDao: ReleaseGroupDao by inject()
+
+    private fun createRepository(
+        coverArtUrlsProducer: (id: String, entity: MusicBrainzEntity) -> List<CoverArtUrls>,
+    ): ImageMetadataRepositoryImpl {
+        return ImageMetadataRepositoryImpl(
+            coverArtArchiveApi = object : NoOpCoverArtArchiveApi() {
+                override suspend fun getCoverArts(
+                    mbid: String,
+                    entity: MusicBrainzEntity,
+                ): CoverArtsResponse {
+                    return CoverArtsResponse(
+                        coverArtUrls = coverArtUrlsProducer(mbid, entity),
+                    )
+                }
+            },
+            imageUrlDao = imageUrlDao,
+            logger = object : Logger {
+                override fun d(text: String) {
+                    error(text)
+                }
+
+                override fun e(exception: Exception) {
+                    error(exception)
+                }
+            },
+            coroutineScope = TestScope(coroutineDispatchers.io),
+        )
+    }
+
+    @Test
+    fun empty() = runTest {
+        val repository = createRepository(coverArtUrlsProducer = { _, _ -> listOf() })
+        val imageMetadata = repository.getImageMetadata(
+            mbid = "",
+            entity = MusicBrainzEntity.RELEASE,
+            forceRefresh = false,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 1L,
+            ),
+            imageMetadata,
+        )
+        assertEquals(
+            0,
+            repository.getNumberOfImageMetadataById(""),
+        )
+
+        val flow = repository.observeAllImageMetadata(
+            mbid = null,
+            query = "",
+            sortOption = CoverArtsSortOption.RECENTLY_ADDED,
+        )
+        val imageMetadataList = flow.asSnapshot()
+        assertEquals(
+            true,
+            imageMetadataList.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `get event cover art`() = runTest {
+        val eventId = "a"
+        val eventName = "aa"
+        val eventDisambiguation = "d"
+        eventDao.insert(
+            EventMusicBrainzModel(
+                id = eventId,
+                name = eventName,
+                disambiguation = eventDisambiguation,
+            ),
+        )
+        val repository = createRepository(
+            coverArtUrlsProducer = { _, _ ->
+                listOf(
+                    CoverArtUrls(
+                        imageUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                        front = true,
+                        thumbnailsUrls = ThumbnailsUrls(
+                            resolution250Url = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                        ),
+                    ),
+                )
+            },
+        )
+        val imageMetadata = repository.getImageMetadata(
+            mbid = eventId,
+            entity = MusicBrainzEntity.EVENT,
+            forceRefresh = false,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 1L,
+                thumbnailUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                largeUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+            ),
+            imageMetadata,
+        )
+        assertEquals(
+            1,
+            repository.getNumberOfImageMetadataById(eventId),
+        )
+
+        val flow = repository.observeAllImageMetadata(
+            mbid = null,
+            query = "",
+            sortOption = CoverArtsSortOption.RECENTLY_ADDED,
+        )
+        val imageMetadataList = flow.asSnapshot()
+        assertEquals(
+            1,
+            imageMetadataList.size,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 1L,
+                thumbnailUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                largeUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                mbid = eventId,
+                name = eventName,
+                disambiguation = eventDisambiguation,
+                entity = MusicBrainzEntity.EVENT,
+            ),
+            imageMetadataList[0],
+        )
+    }
+
+    @Test
+    fun `get release cover art`() = runTest {
+        val releaseId = "a"
+        val releaseName = "aa"
+        val releaseDisambiguation = "d"
+        releaseDao.insert(
+            ReleaseMusicBrainzModel(
+                id = releaseId,
+                name = releaseName,
+                disambiguation = releaseDisambiguation,
+            ),
+        )
+        val repository = createRepository(
+            coverArtUrlsProducer = { _, _ ->
+                listOf(
+                    CoverArtUrls(
+                        imageUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                        front = true,
+                        thumbnailsUrls = ThumbnailsUrls(
+                            resolution250Url = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                        ),
+                    ),
+                )
+            },
+        )
+        val imageMetadata = repository.getImageMetadata(
+            mbid = releaseId,
+            entity = MusicBrainzEntity.RELEASE,
+            forceRefresh = false,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 1L,
+                thumbnailUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                largeUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+            ),
+            imageMetadata,
+        )
+        assertEquals(
+            1,
+            repository.getNumberOfImageMetadataById(releaseId),
+        )
+
+        val flow = repository.observeAllImageMetadata(
+            mbid = null,
+            query = "",
+            sortOption = CoverArtsSortOption.RECENTLY_ADDED,
+        )
+        val imageMetadataList = flow.asSnapshot()
+        assertEquals(
+            1,
+            imageMetadataList.size,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 1L,
+                thumbnailUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                largeUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                mbid = releaseId,
+                name = releaseName,
+                disambiguation = releaseDisambiguation,
+                entity = MusicBrainzEntity.RELEASE,
+            ),
+            imageMetadataList[0],
+        )
+    }
+
+    @Test
+    fun `deleting release will still show cover art`() = runTest {
+        val releaseId = "a"
+        val releaseName = "aa"
+        val releaseDisambiguation = "d"
+        releaseDao.insert(
+            ReleaseMusicBrainzModel(
+                id = releaseId,
+                name = releaseName,
+                disambiguation = releaseDisambiguation,
+            ),
+        )
+        val repository = createRepository(
+            coverArtUrlsProducer = { _, _ ->
+                listOf(
+                    CoverArtUrls(
+                        imageUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                        front = true,
+                        thumbnailsUrls = ThumbnailsUrls(
+                            resolution250Url = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                        ),
+                    ),
+                )
+            },
+        )
+        val imageMetadata = repository.getImageMetadata(
+            mbid = releaseId,
+            entity = MusicBrainzEntity.RELEASE,
+            forceRefresh = false,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 1L,
+                thumbnailUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                largeUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+            ),
+            imageMetadata,
+        )
+
+        releaseDao.delete(releaseId)
+        assertEquals(
+            1,
+            repository.getNumberOfImageMetadataById(releaseId),
+        )
+        val flow = repository.observeAllImageMetadata(
+            mbid = null,
+            query = "",
+            sortOption = CoverArtsSortOption.RECENTLY_ADDED,
+        )
+        val imageMetadataList = flow.asSnapshot()
+        assertEquals(
+            1,
+            imageMetadataList.size,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 1L,
+                thumbnailUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                largeUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                mbid = releaseId,
+                name = null,
+                disambiguation = null,
+                entity = null,
+            ),
+            imageMetadataList[0],
+        )
+    }
+
+    @Test
+    fun `get release group cover art`() = runTest {
+        val releaseGroupId = "a"
+        val releaseGroupName = "aa"
+        val releaseGroupDisambiguation = "d"
+        releaseGroupDao.insert(
+            ReleaseGroupMusicBrainzModel(
+                id = releaseGroupId,
+                name = releaseGroupName,
+                disambiguation = releaseGroupDisambiguation,
+            ),
+        )
+        val repository = createRepository(
+            coverArtUrlsProducer = { _, _ ->
+                listOf(
+                    CoverArtUrls(
+                        imageUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                        front = true,
+                        thumbnailsUrls = ThumbnailsUrls(
+                            resolution250Url = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                        ),
+                    ),
+                )
+            },
+        )
+        val imageMetadata = repository.getImageMetadata(
+            mbid = releaseGroupId,
+            entity = MusicBrainzEntity.RELEASE_GROUP,
+            forceRefresh = false,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 1L,
+                thumbnailUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                largeUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+            ),
+            imageMetadata,
+        )
+        assertEquals(
+            1,
+            repository.getNumberOfImageMetadataById(releaseGroupId),
+        )
+
+        val flow = repository.observeAllImageMetadata(
+            mbid = null,
+            query = "",
+            sortOption = CoverArtsSortOption.RECENTLY_ADDED,
+        )
+        val imageMetadataList = flow.asSnapshot()
+        assertEquals(
+            1,
+            imageMetadataList.size,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 1L,
+                thumbnailUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                largeUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
+                mbid = releaseGroupId,
+                name = releaseGroupName,
+                disambiguation = releaseGroupDisambiguation,
+                entity = MusicBrainzEntity.RELEASE_GROUP,
+            ),
+            imageMetadataList[0],
+        )
+    }
+
+    @Test
+    fun `get event, release, release group cover arts, then sort`() = runTest {
+        val eventId = "event-id"
+        val eventName = "event name"
+        val eventDisambiguation = "d"
+        val repository = createRepository(
+            coverArtUrlsProducer = { mbid, entity ->
+                listOf(
+                    CoverArtUrls(
+                        imageUrl = "not used right now",
+                        front = true,
+                        thumbnailsUrls = ThumbnailsUrls(
+                            resolution250Url = "http://someartarchive.org/${entity.resourceUri}/$mbid/1.png",
+                        ),
+                    ),
+                )
+            },
+        )
+
+        eventDao.insert(
+            EventMusicBrainzModel(
+                id = eventId,
+                name = eventName,
+                disambiguation = eventDisambiguation,
+            ),
+        )
+        val eventImageMetadata = repository.getImageMetadata(
+            mbid = eventId,
+            entity = MusicBrainzEntity.EVENT,
+            forceRefresh = false,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 1L,
+                thumbnailUrl = "http://someartarchive.org/event/$eventId/1.png",
+                largeUrl = "http://someartarchive.org/event/$eventId/1.png",
+            ),
+            eventImageMetadata,
+        )
+        assertEquals(
+            1,
+            repository.getNumberOfImageMetadataById(eventId),
+        )
+
+        val releaseId = "release-id"
+        val releaseName = "release name"
+        val releaseDisambiguation = "d"
+        releaseDao.insert(
+            ReleaseMusicBrainzModel(
+                id = releaseId,
+                name = releaseName,
+                disambiguation = releaseDisambiguation,
+            ),
+        )
+        val releaseImageMetadata = repository.getImageMetadata(
+            mbid = releaseId,
+            entity = MusicBrainzEntity.RELEASE,
+            forceRefresh = false,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 2L,
+                thumbnailUrl = "http://someartarchive.org/release/$releaseId/1.png",
+                largeUrl = "http://someartarchive.org/release/$releaseId/1.png",
+            ),
+            releaseImageMetadata,
+        )
+        assertEquals(
+            1,
+            repository.getNumberOfImageMetadataById(releaseId),
+        )
+
+        val releaseGroupId = "release-group-id"
+        val releaseGroupName = "release group name"
+        val releaseGroupDisambiguation = "d"
+        releaseGroupDao.insert(
+            ReleaseGroupMusicBrainzModel(
+                id = releaseGroupId,
+                name = releaseGroupName,
+                disambiguation = releaseGroupDisambiguation,
+            ),
+        )
+        val releaseGroupImageMetadata = repository.getImageMetadata(
+            mbid = releaseGroupId,
+            entity = MusicBrainzEntity.RELEASE_GROUP,
+            forceRefresh = false,
+        )
+        assertEquals(
+            ImageMetadata(
+                databaseId = 3L,
+                thumbnailUrl = "http://someartarchive.org/release-group/$releaseGroupId/1.png",
+                largeUrl = "http://someartarchive.org/release-group/$releaseGroupId/1.png",
+            ),
+            releaseGroupImageMetadata,
+        )
+        assertEquals(
+            1,
+            repository.getNumberOfImageMetadataById(releaseGroupId),
+        )
+
+        repository.observeAllImageMetadata(
+            mbid = null,
+            query = "",
+            sortOption = CoverArtsSortOption.RECENTLY_ADDED,
+        ).asSnapshot().let { imageMetadataList ->
+            assertEquals(
+                3,
+                imageMetadataList.size,
+            )
+            assertEquals(
+                listOf(
+                    ImageMetadata(
+                        databaseId = 3L,
+                        thumbnailUrl = "http://someartarchive.org/release-group/$releaseGroupId/1.png",
+                        largeUrl = "http://someartarchive.org/release-group/$releaseGroupId/1.png",
+                        mbid = releaseGroupId,
+                        name = releaseGroupName,
+                        disambiguation = releaseGroupDisambiguation,
+                        entity = MusicBrainzEntity.RELEASE_GROUP,
+                    ),
+                    ImageMetadata(
+                        databaseId = 2L,
+                        thumbnailUrl = "http://someartarchive.org/release/$releaseId/1.png",
+                        largeUrl = "http://someartarchive.org/release/$releaseId/1.png",
+                        mbid = releaseId,
+                        name = releaseName,
+                        disambiguation = releaseDisambiguation,
+                        entity = MusicBrainzEntity.RELEASE,
+                    ),
+                    ImageMetadata(
+                        databaseId = 1L,
+                        thumbnailUrl = "http://someartarchive.org/event/$eventId/1.png",
+                        largeUrl = "http://someartarchive.org/event/$eventId/1.png",
+                        mbid = eventId,
+                        name = eventName,
+                        disambiguation = eventDisambiguation,
+                        entity = MusicBrainzEntity.EVENT,
+                    ),
+                ),
+                imageMetadataList,
+            )
+        }
+
+        repository.observeAllImageMetadata(
+            mbid = null,
+            query = "",
+            sortOption = CoverArtsSortOption.LEAST_RECENTLY_ADDED,
+        ).asSnapshot().let { imageMetadataList ->
+            assertEquals(
+                3,
+                imageMetadataList.size,
+            )
+            assertEquals(
+                listOf(
+                    ImageMetadata(
+                        databaseId = 1L,
+                        thumbnailUrl = "http://someartarchive.org/event/$eventId/1.png",
+                        largeUrl = "http://someartarchive.org/event/$eventId/1.png",
+                        mbid = eventId,
+                        name = eventName,
+                        disambiguation = eventDisambiguation,
+                        entity = MusicBrainzEntity.EVENT,
+                    ),
+                    ImageMetadata(
+                        databaseId = 2L,
+                        thumbnailUrl = "http://someartarchive.org/release/$releaseId/1.png",
+                        largeUrl = "http://someartarchive.org/release/$releaseId/1.png",
+                        mbid = releaseId,
+                        name = releaseName,
+                        disambiguation = releaseDisambiguation,
+                        entity = MusicBrainzEntity.RELEASE,
+                    ),
+                    ImageMetadata(
+                        databaseId = 3L,
+                        thumbnailUrl = "http://someartarchive.org/release-group/$releaseGroupId/1.png",
+                        largeUrl = "http://someartarchive.org/release-group/$releaseGroupId/1.png",
+                        mbid = releaseGroupId,
+                        name = releaseGroupName,
+                        disambiguation = releaseGroupDisambiguation,
+                        entity = MusicBrainzEntity.RELEASE_GROUP,
+                    ),
+                ),
+                imageMetadataList,
+            )
+        }
+
+        repository.observeAllImageMetadata(
+            mbid = null,
+            query = "",
+            sortOption = CoverArtsSortOption.ALPHABETICALLY,
+        ).asSnapshot().let { imageMetadataList ->
+            assertEquals(
+                3,
+                imageMetadataList.size,
+            )
+            assertEquals(
+                listOf(
+                    ImageMetadata(
+                        databaseId = 1L,
+                        thumbnailUrl = "http://someartarchive.org/event/$eventId/1.png",
+                        largeUrl = "http://someartarchive.org/event/$eventId/1.png",
+                        mbid = eventId,
+                        name = eventName,
+                        disambiguation = eventDisambiguation,
+                        entity = MusicBrainzEntity.EVENT,
+                    ),
+                    ImageMetadata(
+                        databaseId = 3L,
+                        thumbnailUrl = "http://someartarchive.org/release-group/$releaseGroupId/1.png",
+                        largeUrl = "http://someartarchive.org/release-group/$releaseGroupId/1.png",
+                        mbid = releaseGroupId,
+                        name = releaseGroupName,
+                        disambiguation = releaseGroupDisambiguation,
+                        entity = MusicBrainzEntity.RELEASE_GROUP,
+                    ),
+                    ImageMetadata(
+                        databaseId = 2L,
+                        thumbnailUrl = "http://someartarchive.org/release/$releaseId/1.png",
+                        largeUrl = "http://someartarchive.org/release/$releaseId/1.png",
+                        mbid = releaseId,
+                        name = releaseName,
+                        disambiguation = releaseDisambiguation,
+                        entity = MusicBrainzEntity.RELEASE,
+                    ),
+                ),
+                imageMetadataList,
+            )
+        }
+
+        repository.observeAllImageMetadata(
+            mbid = null,
+            query = "",
+            sortOption = CoverArtsSortOption.ALPHABETICALLY_REVERSE,
+        ).asSnapshot().let { imageMetadataList ->
+            assertEquals(
+                3,
+                imageMetadataList.size,
+            )
+            assertEquals(
+                listOf(
+                    ImageMetadata(
+                        databaseId = 2L,
+                        thumbnailUrl = "http://someartarchive.org/release/$releaseId/1.png",
+                        largeUrl = "http://someartarchive.org/release/$releaseId/1.png",
+                        mbid = releaseId,
+                        name = releaseName,
+                        disambiguation = releaseDisambiguation,
+                        entity = MusicBrainzEntity.RELEASE,
+                    ),
+                    ImageMetadata(
+                        databaseId = 3L,
+                        thumbnailUrl = "http://someartarchive.org/release-group/$releaseGroupId/1.png",
+                        largeUrl = "http://someartarchive.org/release-group/$releaseGroupId/1.png",
+                        mbid = releaseGroupId,
+                        name = releaseGroupName,
+                        disambiguation = releaseGroupDisambiguation,
+                        entity = MusicBrainzEntity.RELEASE_GROUP,
+                    ),
+                    ImageMetadata(
+                        databaseId = 1L,
+                        thumbnailUrl = "http://someartarchive.org/event/$eventId/1.png",
+                        largeUrl = "http://someartarchive.org/event/$eventId/1.png",
+                        mbid = eventId,
+                        name = eventName,
+                        disambiguation = eventDisambiguation,
+                        entity = MusicBrainzEntity.EVENT,
+                    ),
+                ),
+                imageMetadataList,
+            )
+        }
+    }
+}

--- a/data/database/src/commonMain/sqldelight/ly.david.musicsearch.data.database/mbid_image.sq
+++ b/data/database/src/commonMain/sqldelight/ly.david.musicsearch.data.database/mbid_image.sq
@@ -14,6 +14,46 @@ CREATE TABLE IF NOT EXISTS mbid_image (
 
 CREATE INDEX IF NOT EXISTS idx_mbid_image_mbid ON mbid_image(`mbid`);
 
+CREATE VIEW IF NOT EXISTS coalesced_entity AS
+SELECT
+  id,
+  name,
+  sort_name,
+  disambiguation,
+  'artist' AS entity_type
+FROM artist
+
+UNION ALL
+
+SELECT
+  id,
+  name,
+  NULL AS sort_name,
+  disambiguation,
+  'event' AS entity_type
+FROM event
+
+UNION ALL
+
+SELECT
+  id,
+  name,
+  NULL AS sort_name,
+  disambiguation,
+  'release' AS entity_type
+FROM `release`
+
+UNION ALL
+
+SELECT
+  id,
+  name,
+  NULL AS sort_name,
+  disambiguation,
+  'release-group' AS entity_type
+FROM release_group;
+
+
 insert:
 INSERT OR IGNORE INTO mbid_image (
   `mbid`,
@@ -70,23 +110,14 @@ OFFSET :offset;
 getAllImageMetadataCount:
 SELECT count(mbid_image.`id`)
 FROM mbid_image
-LEFT JOIN artist ON artist.id = mbid_image.mbid
-LEFT JOIN event ON event.id = mbid_image.mbid
-LEFT JOIN `release` ON `release`.id = mbid_image.mbid
-LEFT JOIN release_group ON release_group.id = mbid_image.mbid
+LEFT JOIN coalesced_entity ON coalesced_entity.id = mbid_image.mbid
 WHERE thumbnail_url != ''
 AND (
   types LIKE :query OR
   comment LIKE :query OR
-  artist.name LIKE :query OR
-  artist.sort_name LIKE :query OR
-  artist.disambiguation LIKE :query OR
-  event.name LIKE :query OR
-  event.disambiguation LIKE :query OR
-  `release`.name LIKE :query OR
-  `release`.disambiguation LIKE :query OR
-  release_group.name LIKE :query OR
-  release_group.disambiguation LIKE :query
+  coalesced_entity.name LIKE :query OR
+  coalesced_entity.sort_name LIKE :query OR
+  coalesced_entity.disambiguation LIKE :query
 );
 
 getAllImageMetadata:
@@ -97,46 +128,22 @@ SELECT
   mbid_image.`types`,
   mbid_image.`comment`,
   mbid_image.mbid,
-  coalesce(
-    artist.name,
-    event.name,
-    `release`.name,
-    release_group.name
-  ) AS coalesced_name,
-  coalesce(
-    artist.disambiguation,
-    event.disambiguation,
-    `release`.disambiguation,
-    release_group.disambiguation
-  ) AS disambiguation,
-  CASE
-    WHEN artist.name IS NOT NULL THEN 'artist'
-    WHEN event.name IS NOT NULL THEN 'event'
-    WHEN `release`.name IS NOT NULL THEN 'release'
-    WHEN release_group.name IS NOT NULL THEN 'release-group'
-  END AS entity
+  coalesced_entity.name,
+  coalesced_entity.disambiguation,
+  coalesced_entity.entity_type
 FROM mbid_image
-LEFT JOIN artist ON artist.id = mbid_image.mbid
-LEFT JOIN event ON event.id = mbid_image.mbid
-LEFT JOIN `release` ON `release`.id = mbid_image.mbid
-LEFT JOIN release_group ON release_group.id = mbid_image.mbid
+LEFT JOIN coalesced_entity ON coalesced_entity.id = mbid_image.mbid
 WHERE thumbnail_url != ''
 AND (
   types LIKE :query OR
   comment LIKE :query OR
-  artist.name LIKE :query OR
-  artist.sort_name LIKE :query OR
-  artist.disambiguation LIKE :query OR
-  event.name LIKE :query OR
-  event.disambiguation LIKE :query OR
-  `release`.name LIKE :query OR
-  `release`.disambiguation LIKE :query OR
-  release_group.name LIKE :query OR
-  release_group.disambiguation LIKE :query
+  coalesced_entity.name LIKE :query OR
+  coalesced_entity.sort_name LIKE :query OR
+  coalesced_entity.disambiguation LIKE :query
 )
 ORDER BY
-  CASE WHEN :alphabetically THEN `coalesced_name` END ASC,
-  CASE WHEN :alphabeticallyReverse THEN `coalesced_name` END DESC,
+  CASE WHEN :alphabetically THEN coalesced_entity.name END ASC,
+  CASE WHEN :alphabeticallyReverse THEN coalesced_entity.name END DESC,
   CASE WHEN :recentlyAdded THEN mbid_image.id END DESC,
   CASE WHEN :leastRecentlyAdded THEN mbid_image.id END ASC
 LIMIT :limit

--- a/data/database/src/commonMain/sqldelight/migrations/26.sqm
+++ b/data/database/src/commonMain/sqldelight/migrations/26.sqm
@@ -1,0 +1,38 @@
+CREATE VIEW IF NOT EXISTS coalesced_entity AS
+SELECT
+  id,
+  name,
+  sort_name,
+  disambiguation,
+  'artist' AS entity_type
+FROM artist
+
+UNION ALL
+
+SELECT
+  id,
+  name,
+  NULL AS sort_name,
+  disambiguation,
+  'event' AS entity_type
+FROM event
+
+UNION ALL
+
+SELECT
+  id,
+  name,
+  NULL AS sort_name,
+  disambiguation,
+  'release' AS entity_type
+FROM `release`
+
+UNION ALL
+
+SELECT
+  id,
+  name,
+  NULL AS sort_name,
+  disambiguation,
+  'release-group' AS entity_type
+FROM release_group;

--- a/data/repository/build.gradle.kts
+++ b/data/repository/build.gradle.kts
@@ -44,15 +44,5 @@ kotlin {
                 implementation(libs.androidx.paging.testing)
             }
         }
-        val androidUnitTest by getting {
-            dependencies {
-                implementation(libs.sqldelight.sqlite.driver)
-            }
-        }
-        val jvmTest by getting {
-            dependencies {
-                implementation(libs.sqldelight.sqlite.driver)
-            }
-        }
     }
 }

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/area/AreaRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/area/AreaRepositoryImplTest.kt
@@ -7,7 +7,7 @@ import ly.david.musicsearch.data.database.dao.EntityHasRelationsDao
 import ly.david.musicsearch.shared.domain.history.VisitedDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.musicbrainz.models.core.AreaMusicBrainzModel
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.shared.domain.area.AreaDetailsModel
 import ly.david.musicsearch.shared.domain.area.AreaType.COUNTRY

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/artist/ArtistRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/artist/ArtistRepositoryImplTest.kt
@@ -18,7 +18,7 @@ import ly.david.musicsearch.data.musicbrainz.api.BrowseArtistsResponse
 import ly.david.musicsearch.data.musicbrainz.models.common.LifeSpanMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.core.AreaMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.core.ArtistMusicBrainzModel
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.shared.domain.LifeSpanUiModel
 import ly.david.musicsearch.shared.domain.ListFilters

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/collection/CollectionRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/collection/CollectionRepositoryImplTest.kt
@@ -12,8 +12,8 @@ import ly.david.musicsearch.data.musicbrainz.api.BrowseCollectionsResponse
 import ly.david.musicsearch.data.musicbrainz.api.CollectionApi
 import ly.david.musicsearch.data.musicbrainz.models.core.CollectionMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
-import ly.david.musicsearch.data.repository.KoinTestRule
-import ly.david.musicsearch.shared.domain.browse.BrowseEntityCountRepository
+import ly.david.musicsearch.data.repository.BrowseEntityCountRepositoryImpl
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.shared.domain.collection.CollectionSortOption
 import ly.david.musicsearch.shared.domain.listitem.CollectionListItemModel
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
@@ -33,7 +33,6 @@ class CollectionRepositoryImplTest : KoinTest {
     private val collectionDao: CollectionDao by inject()
     private val collectionEntityDao: CollectionEntityDao by inject()
     private val browseEntityCountDao: BrowseEntityCountDao by inject()
-    private val browseEntityCountRepository: BrowseEntityCountRepository by inject()
 
     private fun createRepositoryWithFakeNetworkData(
         collectionApi: CollectionApi,
@@ -43,7 +42,9 @@ class CollectionRepositoryImplTest : KoinTest {
             collectionDao = collectionDao,
             collectionEntityDao = collectionEntityDao,
             browseEntityCountDao = browseEntityCountDao,
-            browseEntityCountRepository = browseEntityCountRepository,
+            browseEntityCountRepository = BrowseEntityCountRepositoryImpl(
+                browseEntityCountDao = browseEntityCountDao,
+            ),
         )
     }
 

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/event/EventRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/event/EventRepositoryImplTest.kt
@@ -12,7 +12,7 @@ import ly.david.musicsearch.data.musicbrainz.models.core.EventMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.Direction
 import ly.david.musicsearch.data.musicbrainz.models.relation.RelationMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.shared.domain.LifeSpanUiModel
 import ly.david.musicsearch.shared.domain.event.EventDetailsModel

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/history/LookupHistoryRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/history/LookupHistoryRepositoryImplTest.kt
@@ -4,7 +4,7 @@ import androidx.paging.testing.asSnapshot
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import ly.david.musicsearch.data.database.dao.LookupHistoryDao
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.LookupHistoryRepositoryImpl
 import ly.david.musicsearch.shared.domain.history.HistorySortOption
 import ly.david.musicsearch.shared.domain.history.LookupHistory

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/instrument/InstrumentRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/instrument/InstrumentRepositoryImplTest.kt
@@ -11,7 +11,7 @@ import ly.david.musicsearch.data.musicbrainz.models.core.InstrumentMusicBrainzMo
 import ly.david.musicsearch.data.musicbrainz.models.relation.Direction
 import ly.david.musicsearch.data.musicbrainz.models.relation.RelationMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.shared.domain.instrument.InstrumentDetailsModel
 import ly.david.musicsearch.shared.domain.listitem.RelationListItemModel

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/label/LabelRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/label/LabelRepositoryImplTest.kt
@@ -13,7 +13,7 @@ import ly.david.musicsearch.data.musicbrainz.models.core.LabelMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.Direction
 import ly.david.musicsearch.data.musicbrainz.models.relation.RelationMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.shared.domain.LifeSpanUiModel
 import ly.david.musicsearch.shared.domain.label.LabelDetailsModel

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/place/PlaceRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/place/PlaceRepositoryImplTest.kt
@@ -22,7 +22,7 @@ import ly.david.musicsearch.data.musicbrainz.models.core.PlaceMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.Direction
 import ly.david.musicsearch.data.musicbrainz.models.relation.RelationMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.data.repository.area.AreaRepositoryImpl
 import ly.david.musicsearch.shared.domain.LifeSpanUiModel

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/recording/RecordingRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/recording/RecordingRepositoryImplTest.kt
@@ -14,7 +14,7 @@ import ly.david.musicsearch.data.musicbrainz.models.core.RecordingMusicBrainzMod
 import ly.david.musicsearch.data.musicbrainz.models.relation.Direction
 import ly.david.musicsearch.data.musicbrainz.models.relation.RelationMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.shared.domain.artist.ArtistCreditUiModel
 import ly.david.musicsearch.shared.domain.listitem.RelationListItemModel

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/relation/RelationRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/relation/RelationRepositoryImplTest.kt
@@ -13,7 +13,7 @@ import ly.david.musicsearch.data.musicbrainz.models.relation.AttributeValue
 import ly.david.musicsearch.data.musicbrainz.models.relation.Direction
 import ly.david.musicsearch.data.musicbrainz.models.relation.RelationMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.shared.domain.history.VisitedDao
 import ly.david.musicsearch.shared.domain.listitem.RelationListItemModel

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/release/ReleaseRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/release/ReleaseRepositoryImplTest.kt
@@ -33,7 +33,7 @@ import ly.david.musicsearch.data.musicbrainz.models.core.TextRepresentationMusic
 import ly.david.musicsearch.data.musicbrainz.models.relation.Direction
 import ly.david.musicsearch.data.musicbrainz.models.relation.RelationMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.shared.domain.artist.ArtistCreditUiModel
 import ly.david.musicsearch.shared.domain.listitem.AreaListItemModel

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/release/ReleasesByEntityRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/release/ReleasesByEntityRepositoryImplTest.kt
@@ -18,7 +18,7 @@ import ly.david.musicsearch.data.database.dao.ReleaseLabelDao
 import ly.david.musicsearch.data.database.dao.ReleaseReleaseGroupDao
 import ly.david.musicsearch.data.musicbrainz.api.BrowseReleasesResponse
 import ly.david.musicsearch.data.musicbrainz.models.core.ReleaseMusicBrainzModel
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.shared.domain.ListFilters
 import ly.david.musicsearch.shared.domain.listitem.ReleaseListItemModel
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/releasegroup/ReleaseGroupRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/releasegroup/ReleaseGroupRepositoryImplTest.kt
@@ -14,7 +14,7 @@ import ly.david.musicsearch.data.musicbrainz.models.core.ReleaseGroupMusicBrainz
 import ly.david.musicsearch.data.musicbrainz.models.relation.Direction
 import ly.david.musicsearch.data.musicbrainz.models.relation.RelationMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.shared.domain.artist.ArtistCreditUiModel
 import ly.david.musicsearch.shared.domain.listitem.RelationListItemModel

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/search/SearchResultsRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/search/SearchResultsRepositoryImplTest.kt
@@ -27,7 +27,7 @@ import ly.david.musicsearch.data.musicbrainz.models.core.AreaMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.core.ArtistMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.core.EventMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.core.ReleaseMusicBrainzModel
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.shared.domain.listitem.AreaListItemModel
 import ly.david.musicsearch.shared.domain.listitem.ArtistListItemModel
 import ly.david.musicsearch.shared.domain.listitem.EndOfList

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/series/SeriesRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/series/SeriesRepositoryImplTest.kt
@@ -1,20 +1,16 @@
 package ly.david.musicsearch.data.repository.series
 
-import androidx.paging.testing.asSnapshot
 import kotlinx.coroutines.test.runTest
 import ly.david.data.test.api.FakeLookupApi
 import ly.david.musicsearch.data.database.dao.EntityHasRelationsDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.SeriesDao
 import ly.david.musicsearch.data.musicbrainz.models.UrlMusicBrainzModel
-import ly.david.musicsearch.data.musicbrainz.models.core.LabelMusicBrainzModel
-import ly.david.musicsearch.data.musicbrainz.models.core.ReleaseGroupMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.core.SeriesMusicBrainzModel
-import ly.david.musicsearch.data.musicbrainz.models.relation.AttributeValue
 import ly.david.musicsearch.data.musicbrainz.models.relation.Direction
 import ly.david.musicsearch.data.musicbrainz.models.relation.RelationMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.shared.domain.history.VisitedDao
 import ly.david.musicsearch.shared.domain.listitem.RelationListItemModel

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/work/WorkRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/work/WorkRepositoryImplTest.kt
@@ -12,7 +12,7 @@ import ly.david.musicsearch.data.musicbrainz.models.core.WorkMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.Direction
 import ly.david.musicsearch.data.musicbrainz.models.relation.RelationMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
-import ly.david.musicsearch.data.repository.KoinTestRule
+import ly.david.data.test.KoinTestRule
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.shared.domain.history.VisitedDao
 import ly.david.musicsearch.shared.domain.listitem.RelationListItemModel

--- a/data/spotify/src/commonMain/kotlin/ly/david/musicsearch/data/spotify/api/SpotifyArtist.kt
+++ b/data/spotify/src/commonMain/kotlin/ly/david/musicsearch/data/spotify/api/SpotifyArtist.kt
@@ -7,10 +7,10 @@ data class SpotifyArtist(
     val images: List<SpotifyImage>? = null,
 )
 
-fun SpotifyArtist.getLargeImageUrl(): String {
+internal fun SpotifyArtist.getLargeImageUrl(): String {
     return images?.maxByOrNull { it.width }?.url.orEmpty()
 }
 
-fun SpotifyArtist.getThumbnailImageUrl(): String {
+internal fun SpotifyArtist.getThumbnailImageUrl(): String {
     return images?.minByOrNull { it.width }?.url.orEmpty()
 }

--- a/shared/domain/src/commonMain/kotlin/ly/david/musicsearch/shared/domain/image/ImageMetadataRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/ly/david/musicsearch/shared/domain/image/ImageMetadataRepository.kt
@@ -1,11 +1,14 @@
-package ly.david.musicsearch.shared.domain.release
+package ly.david.musicsearch.shared.domain.image
 
 import app.cash.paging.PagingData
 import kotlinx.coroutines.flow.Flow
 import ly.david.musicsearch.shared.domain.coverarts.CoverArtsSortOption
-import ly.david.musicsearch.shared.domain.image.ImageMetadata
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
+import ly.david.musicsearch.shared.domain.artist.ArtistImageRepository
 
+/**
+ * See [ArtistImageRepository] for artists.
+ */
 interface ImageMetadataRepository {
     /**
      * Returns a url to the cover art.

--- a/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/event/EventPresenter.kt
+++ b/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/event/EventPresenter.kt
@@ -26,7 +26,7 @@ import ly.david.musicsearch.shared.domain.history.LookupHistory
 import ly.david.musicsearch.shared.domain.history.usecase.IncrementLookupHistory
 import ly.david.musicsearch.shared.domain.musicbrainz.usecase.GetMusicBrainzUrl
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
-import ly.david.musicsearch.shared.domain.release.ImageMetadataRepository
+import ly.david.musicsearch.shared.domain.image.ImageMetadataRepository
 import ly.david.musicsearch.shared.domain.wikimedia.WikimediaRepository
 import ly.david.musicsearch.ui.common.musicbrainz.LoginPresenter
 import ly.david.musicsearch.ui.common.musicbrainz.LoginUiState

--- a/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/release/ReleasePresenter.kt
+++ b/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/release/ReleasePresenter.kt
@@ -28,7 +28,7 @@ import ly.david.musicsearch.shared.domain.history.usecase.IncrementLookupHistory
 import ly.david.musicsearch.shared.domain.musicbrainz.usecase.GetMusicBrainzUrl
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
 import ly.david.musicsearch.shared.domain.release.ReleaseDetailsModel
-import ly.david.musicsearch.shared.domain.release.ImageMetadataRepository
+import ly.david.musicsearch.shared.domain.image.ImageMetadataRepository
 import ly.david.musicsearch.shared.domain.release.ReleaseRepository
 import ly.david.musicsearch.shared.domain.wikimedia.WikimediaRepository
 import ly.david.musicsearch.ui.common.artist.ArtistsByEntityPresenter

--- a/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/releasegroup/ReleaseGroupPresenter.kt
+++ b/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/releasegroup/ReleaseGroupPresenter.kt
@@ -25,7 +25,7 @@ import ly.david.musicsearch.shared.domain.history.LookupHistory
 import ly.david.musicsearch.shared.domain.history.usecase.IncrementLookupHistory
 import ly.david.musicsearch.shared.domain.musicbrainz.usecase.GetMusicBrainzUrl
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
-import ly.david.musicsearch.shared.domain.release.ImageMetadataRepository
+import ly.david.musicsearch.shared.domain.image.ImageMetadataRepository
 import ly.david.musicsearch.shared.domain.releasegroup.ReleaseGroupDetailsModel
 import ly.david.musicsearch.shared.domain.releasegroup.ReleaseGroupRepository
 import ly.david.musicsearch.shared.domain.wikimedia.WikimediaRepository

--- a/shared/feature/images/src/androidUnitTest/kotlin/ly/david/musicsearch/shared/feature/images/CoverArtsPresenterTest.kt
+++ b/shared/feature/images/src/androidUnitTest/kotlin/ly/david/musicsearch/shared/feature/images/CoverArtsPresenterTest.kt
@@ -14,7 +14,7 @@ import ly.david.musicsearch.shared.domain.image.ImageMetadata
 import ly.david.musicsearch.shared.domain.musicbrainz.usecase.GetMusicBrainzCoverArtUrl
 import ly.david.musicsearch.shared.domain.musicbrainz.usecase.GetMusicBrainzUrl
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
-import ly.david.musicsearch.shared.domain.release.ImageMetadataRepository
+import ly.david.musicsearch.shared.domain.image.ImageMetadataRepository
 import ly.david.musicsearch.ui.common.screen.CoverArtsScreen
 import ly.david.musicsearch.ui.common.screen.SettingsScreen
 import org.junit.Assert.assertEquals

--- a/shared/feature/images/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/images/CoverArtsPresenter.kt
+++ b/shared/feature/images/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/images/CoverArtsPresenter.kt
@@ -26,7 +26,7 @@ import ly.david.musicsearch.shared.domain.image.ImageMetadata
 import ly.david.musicsearch.shared.domain.musicbrainz.usecase.GetMusicBrainzCoverArtUrl
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
 import ly.david.musicsearch.shared.domain.preferences.AppPreferences
-import ly.david.musicsearch.shared.domain.release.ImageMetadataRepository
+import ly.david.musicsearch.shared.domain.image.ImageMetadataRepository
 import ly.david.musicsearch.ui.common.screen.CoverArtsScreen
 import ly.david.musicsearch.ui.common.screen.DetailsScreen
 import ly.david.musicsearch.ui.common.topappbar.TopAppBarFilterState

--- a/test-data/build.gradle.kts
+++ b/test-data/build.gradle.kts
@@ -10,8 +10,18 @@ kotlin {
                 implementation(projects.data.musicbrainz)
                 implementation(projects.data.coverart)
                 implementation(projects.data.spotify)
+                implementation(projects.data.database)
                 implementation(libs.koin.core)
+                implementation(libs.koin.test)
+                implementation(projects.core.coroutines)
                 implementation(libs.kotlinx.coroutines.core)
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.junit)
+            }
+        }
+        val jvmMain by getting {
+            dependencies {
+                implementation(libs.sqldelight.sqlite.driver)
             }
         }
     }

--- a/test-data/src/commonMain/kotlin/ly/david/data/test/api/NoOpCoverArtArchiveApi.kt
+++ b/test-data/src/commonMain/kotlin/ly/david/data/test/api/NoOpCoverArtArchiveApi.kt
@@ -1,22 +1,16 @@
 package ly.david.data.test.api
 
 import ly.david.musicsearch.data.coverart.api.CoverArtArchiveApi
-import ly.david.musicsearch.data.coverart.api.CoverArtUrls
 import ly.david.musicsearch.data.coverart.api.CoverArtsResponse
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
 
-open class FakeCoverArtArchiveApi : CoverArtArchiveApi {
+open class NoOpCoverArtArchiveApi : CoverArtArchiveApi {
     override suspend fun getCoverArts(
         mbid: String,
         entity: MusicBrainzEntity,
     ): CoverArtsResponse {
         return CoverArtsResponse(
-            coverArtUrls = listOf(
-                CoverArtUrls(
-                    imageUrl = "http://coverartarchive.org/release/00e48019-5901-4110-b44d-875c3026491b/247510391.png",
-                    front = true,
-                ),
-            ),
+            coverArtUrls = listOf(),
         )
     }
 }

--- a/test-data/src/jvmMain/kotlin/ly/david/data/test/KoinTestRule.kt
+++ b/test-data/src/jvmMain/kotlin/ly/david/data/test/KoinTestRule.kt
@@ -1,4 +1,4 @@
-package ly.david.musicsearch.data.repository
+package ly.david.data.test
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -7,7 +7,6 @@ import ly.david.musicsearch.core.coroutines.CoroutineDispatchers
 import ly.david.musicsearch.data.database.Database
 import ly.david.musicsearch.data.database.createDatabase
 import ly.david.musicsearch.data.database.databaseDaoModule
-import ly.david.musicsearch.data.repository.di.repositoryDataModule
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 import org.koin.core.context.startKoin
@@ -16,7 +15,7 @@ import org.koin.dsl.module
 import java.util.Properties
 
 @OptIn(ExperimentalCoroutinesApi::class)
-val testCoroutineDispatchersModule = module {
+private val testCoroutineDispatchersModule = module {
     factory {
         val testDispatcher = UnconfinedTestDispatcher()
         CoroutineDispatchers(
@@ -25,8 +24,7 @@ val testCoroutineDispatchersModule = module {
         )
     }
 }
-
-val testDatabaseModule = module {
+private val testDatabaseModule = module {
     single<Database> {
         val driver = JdbcSqliteDriver(
             url = JdbcSqliteDriver.IN_MEMORY,
@@ -47,7 +45,6 @@ class KoinTestRule : TestWatcher() {
         startKoin {
             modules(
                 databaseDaoModule,
-                repositoryDataModule,
                 testCoroutineDispatchersModule,
                 testDatabaseModule,
             )

--- a/ui/common/src/commonMain/kotlin/ly/david/musicsearch/ui/common/release/ReleasesByEntityPresenter.kt
+++ b/ui/common/src/commonMain/kotlin/ly/david/musicsearch/ui/common/release/ReleasesByEntityPresenter.kt
@@ -23,7 +23,7 @@ import ly.david.musicsearch.shared.domain.ListFilters
 import ly.david.musicsearch.shared.domain.listitem.ReleaseListItemModel
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
 import ly.david.musicsearch.shared.domain.preferences.AppPreferences
-import ly.david.musicsearch.shared.domain.release.ImageMetadataRepository
+import ly.david.musicsearch.shared.domain.image.ImageMetadataRepository
 import ly.david.musicsearch.shared.domain.release.usecase.GetReleasesByEntity
 
 class ReleasesByEntityPresenter(

--- a/ui/common/src/commonMain/kotlin/ly/david/musicsearch/ui/common/releasegroup/ReleaseGroupsByEntityPresenter.kt
+++ b/ui/common/src/commonMain/kotlin/ly/david/musicsearch/ui/common/releasegroup/ReleaseGroupsByEntityPresenter.kt
@@ -19,7 +19,7 @@ import ly.david.musicsearch.shared.domain.ListFilters
 import ly.david.musicsearch.shared.domain.listitem.ListItemModel
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
 import ly.david.musicsearch.shared.domain.preferences.AppPreferences
-import ly.david.musicsearch.shared.domain.release.ImageMetadataRepository
+import ly.david.musicsearch.shared.domain.image.ImageMetadataRepository
 import ly.david.musicsearch.shared.domain.releasegroup.usecase.GetReleaseGroupsByEntity
 
 class ReleaseGroupsByEntityPresenter(


### PR DESCRIPTION
union all instead of left join to fix crash that happens when the entity it was linked to has been deleted or had its id changed