### PR TITLE
fix: refreshing events that belong to multiple entities will no longer delete them

### DIFF
--- a/data/database/src/commonMain/sqldelight/ly.david.musicsearch.data.database/event.sq
+++ b/data/database/src/commonMain/sqldelight/ly.david.musicsearch.data.database/event.sq
@@ -48,12 +48,22 @@ INSERT OR FAIL INTO events_by_entity
 VALUES ?;
 
 deleteEventsByEntity {
-DELETE FROM event WHERE id IN (
-  SELECT e.id
-  FROM events_by_entity ee
-  INNER JOIN event e ON e.id = ee.event_id
-  WHERE ee.entity_id = :entityId
-);
+WITH
+  events_linked_to_multiple_entities AS (
+    SELECT event_id
+    FROM events_by_entity
+    GROUP BY event_id
+    HAVING COUNT(DISTINCT entity_id) > 1
+  ),
+  events_to_delete AS (
+    SELECT e.id
+    FROM event e
+    INNER JOIN events_by_entity ee ON e.id = ee.event_id
+    WHERE ee.entity_id = :entityId
+    AND e.id NOT IN (SELECT event_id FROM events_linked_to_multiple_entities)
+  )
+DELETE FROM event
+WHERE id IN (SELECT id FROM events_to_delete);
 
 DELETE FROM events_by_entity WHERE entity_id = :entityId;
 }

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestEventRepository.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestEventRepository.kt
@@ -1,0 +1,48 @@
+package ly.david.musicsearch.data.repository.helpers
+
+import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.EntityHasRelationsDao
+import ly.david.musicsearch.data.database.dao.EventDao
+import ly.david.musicsearch.data.database.dao.RelationDao
+import ly.david.musicsearch.data.musicbrainz.models.core.EventMusicBrainzModel
+import ly.david.musicsearch.data.repository.RelationRepositoryImpl
+import ly.david.musicsearch.data.repository.event.EventRepositoryImpl
+import ly.david.musicsearch.shared.domain.event.EventRepository
+import ly.david.musicsearch.shared.domain.history.VisitedDao
+
+interface TestEventRepository {
+    val entityHasRelationsDao: EntityHasRelationsDao
+    val visitedDao: VisitedDao
+    val relationDao: RelationDao
+    val eventDao: EventDao
+
+    fun createEventRepository(
+        musicBrainzModel: EventMusicBrainzModel,
+    ): EventRepository {
+        val relationRepository = RelationRepositoryImpl(
+            lookupApi = object : FakeLookupApi() {
+                override suspend fun lookupEvent(
+                    eventId: String,
+                    include: String?,
+                ): EventMusicBrainzModel {
+                    return musicBrainzModel
+                }
+            },
+            entityHasRelationsDao = entityHasRelationsDao,
+            visitedDao = visitedDao,
+            relationDao = relationDao,
+        )
+        return EventRepositoryImpl(
+            eventDao = eventDao,
+            relationRepository = relationRepository,
+            lookupApi = object : FakeLookupApi() {
+                override suspend fun lookupEvent(
+                    eventId: String,
+                    include: String?,
+                ): EventMusicBrainzModel {
+                    return musicBrainzModel
+                }
+            },
+        )
+    }
+}

--- a/test-data/src/commonMain/kotlin/ly/david/data/test/TestAreaMusicBrainzModels.kt
+++ b/test-data/src/commonMain/kotlin/ly/david/data/test/TestAreaMusicBrainzModels.kt
@@ -51,3 +51,11 @@ val japanAreaMusicBrainzModel = AreaMusicBrainzModel(
     countryCodes = listOf("JP"),
     type = AreaType.COUNTRY,
 )
+
+val kitanomaruAreaMusicBrainzModel = AreaMusicBrainzModel(
+    id = "e24c0f02-9b5a-4f4f-9fe0-f8b3e67874f8",
+    name = "Kitanomaru Kōen",
+    sortName = "Kitanomaru Kōen",
+    type = "District",
+    typeId = "84039871-5e47-38ca-a66a-45e512c8290f",
+)

--- a/test-data/src/commonMain/kotlin/ly/david/data/test/TestPlaceMusicBrainzModels.kt
+++ b/test-data/src/commonMain/kotlin/ly/david/data/test/TestPlaceMusicBrainzModels.kt
@@ -19,10 +19,7 @@ val budokanPlaceMusicBrainzModel = PlaceMusicBrainzModel(
         longitude = 139.75,
         latitude = 35.69333,
     ),
-    area = AreaMusicBrainzModel(
-        id = "e24c0f02-9b5a-4f4f-9fe0-f8b3e67874f8",
-        name = "Kitanomaru Kōen",
-        sortName = "Kitanomaru Kōen",
+    area = kitanomaruAreaMusicBrainzModel.copy(
         type = null,
         typeId = null,
     ),


### PR DESCRIPTION
#1241