### PR TITLE
fix: less UI reloads when browsing large lists of releases and release groups by batch writing image metadata to database

### DIFF
--- a/data/coverart/src/commonMain/kotlin/ly/david/musicsearch/data/coverart/ImageMetadataRepositoryImpl.kt
+++ b/data/coverart/src/commonMain/kotlin/ly/david/musicsearch/data/coverart/ImageMetadataRepositoryImpl.kt
@@ -5,8 +5,14 @@ import app.cash.paging.Pager
 import app.cash.paging.PagingConfig
 import app.cash.paging.PagingData
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
 import ly.david.musicsearch.core.logging.Logger
 import ly.david.musicsearch.data.coverart.api.CoverArtArchiveApi
 import ly.david.musicsearch.data.coverart.api.CoverArtsResponse
@@ -18,6 +24,7 @@ import ly.david.musicsearch.shared.domain.image.ImageMetadataRepository
 import ly.david.musicsearch.shared.domain.image.ImageUrlDao
 import ly.david.musicsearch.shared.domain.image.ImagesSortOption
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
+import kotlin.time.Duration.Companion.seconds
 
 internal class ImageMetadataRepositoryImpl(
     private val coverArtArchiveApi: CoverArtArchiveApi,
@@ -26,7 +33,7 @@ internal class ImageMetadataRepositoryImpl(
     private val coroutineScope: CoroutineScope,
 ) : ImageMetadataRepository {
 
-    override suspend fun getImageMetadata(
+    override suspend fun getAndSaveImageMetadata(
         mbid: String,
         entity: MusicBrainzEntity,
         forceRefresh: Boolean,
@@ -72,6 +79,84 @@ internal class ImageMetadataRepositoryImpl(
             }
         } catch (ex: Exception) {
             logger.e(ex)
+        }
+    }
+
+    private val mutex = Mutex()
+    private var saveImageMetadataJob: Job? = null
+    private var mbidToImageMetadataMap: MutableMap<String, List<ImageMetadata>> = mutableMapOf()
+    private var lastSaved = Clock.System.now()
+    private var maxWaitTime = 5.seconds
+    private var maxBatchSize: Int = 100
+
+    override suspend fun saveImageMetadata(
+        mbid: String,
+        entity: MusicBrainzEntity,
+    ) {
+        saveImageMetadata(
+            mbid = mbid,
+            entity = entity,
+            skipNetworkCall = false,
+        )
+    }
+
+    private suspend fun saveImageMetadata(
+        mbid: String,
+        entity: MusicBrainzEntity,
+        skipNetworkCall: Boolean = false,
+    ) {
+        if (mbidToImageMetadataMap.isEmpty()) {
+            lastSaved = Clock.System.now()
+        }
+        if (!skipNetworkCall) {
+            try {
+                val coverArts: CoverArtsResponse = coverArtArchiveApi.getCoverArts(mbid, entity)
+                val imageMetadataList: MutableList<ImageMetadata> = coverArts.toImageMetadataList().toMutableList()
+
+                // We use an empty ImageUrls to represent that we've searched but failed to find any images.
+                if (imageMetadataList.isEmpty()) {
+                    imageMetadataList.add(ImageMetadata())
+                }
+
+                mbidToImageMetadataMap[mbid] = imageMetadataList
+                logger.d("Fetched images for $mbid")
+            } catch (ex: HandledException) {
+                if (ex.errorResolution == ErrorResolution.None) {
+                    mbidToImageMetadataMap[mbid] = listOf(ImageMetadata())
+                    logger.d("Saved empty image metadata for $mbid")
+                } else {
+                    logger.e(ex)
+                }
+            } catch (ex: Exception) {
+                logger.e(ex)
+            }
+        }
+
+        saveImageMetadataJob?.cancel()
+        logger.d("cancelling existing job and restarting")
+        saveImageMetadataJob = coroutineScope.launch {
+            val isReadyToSave = mbidToImageMetadataMap.size >= maxBatchSize ||
+                Clock.System.now() - lastSaved >= maxWaitTime
+
+            if (isReadyToSave) {
+                batchSaveImageMetadata()
+            } else {
+                val timeToWait = maxWaitTime - (Clock.System.now() - lastSaved)
+                logger.d("Waiting for $timeToWait")
+                delay(timeToWait)
+                batchSaveImageMetadata()
+            }
+        }
+    }
+
+    private suspend fun batchSaveImageMetadata() {
+        mutex.withLock {
+            imageUrlDao.saveImageMetadata(
+                mbidToImageMetadataMap = mbidToImageMetadataMap,
+            )
+            logger.d("Saved ${mbidToImageMetadataMap.size} image metadata")
+            mbidToImageMetadataMap.clear()
+            lastSaved = Clock.System.now()
         }
     }
 

--- a/data/coverart/src/jvmTest/kotlin/ly/david/musicsearch/data/coverart/ImageMetadataRepositoryImplTest.kt
+++ b/data/coverart/src/jvmTest/kotlin/ly/david/musicsearch/data/coverart/ImageMetadataRepositoryImplTest.kt
@@ -69,7 +69,7 @@ class ImageMetadataRepositoryImplTest : KoinTest {
     @Test
     fun empty() = runTest {
         val repository = createRepository(coverArtUrlsProducer = { _, _ -> listOf() })
-        val imageMetadata = repository.getImageMetadata(
+        val imageMetadata = repository.getAndSaveImageMetadata(
             mbid = "",
             entity = MusicBrainzEntity.RELEASE,
             forceRefresh = false,
@@ -122,7 +122,7 @@ class ImageMetadataRepositoryImplTest : KoinTest {
                 )
             },
         )
-        val imageMetadata = repository.getImageMetadata(
+        val imageMetadata = repository.getAndSaveImageMetadata(
             mbid = eventId,
             entity = MusicBrainzEntity.EVENT,
             forceRefresh = false,
@@ -189,7 +189,7 @@ class ImageMetadataRepositoryImplTest : KoinTest {
                 )
             },
         )
-        val imageMetadata = repository.getImageMetadata(
+        val imageMetadata = repository.getAndSaveImageMetadata(
             mbid = releaseId,
             entity = MusicBrainzEntity.RELEASE,
             forceRefresh = false,
@@ -256,7 +256,7 @@ class ImageMetadataRepositoryImplTest : KoinTest {
                 )
             },
         )
-        val imageMetadata = repository.getImageMetadata(
+        val imageMetadata = repository.getAndSaveImageMetadata(
             mbid = releaseId,
             entity = MusicBrainzEntity.RELEASE,
             forceRefresh = false,
@@ -324,7 +324,7 @@ class ImageMetadataRepositoryImplTest : KoinTest {
                 )
             },
         )
-        val imageMetadata = repository.getImageMetadata(
+        val imageMetadata = repository.getAndSaveImageMetadata(
             mbid = releaseGroupId,
             entity = MusicBrainzEntity.RELEASE_GROUP,
             forceRefresh = false,
@@ -392,7 +392,7 @@ class ImageMetadataRepositoryImplTest : KoinTest {
                 disambiguation = eventDisambiguation,
             ),
         )
-        val eventImageMetadata = repository.getImageMetadata(
+        val eventImageMetadata = repository.getAndSaveImageMetadata(
             mbid = eventId,
             entity = MusicBrainzEntity.EVENT,
             forceRefresh = false,
@@ -420,7 +420,7 @@ class ImageMetadataRepositoryImplTest : KoinTest {
                 disambiguation = releaseDisambiguation,
             ),
         )
-        val releaseImageMetadata = repository.getImageMetadata(
+        val releaseImageMetadata = repository.getAndSaveImageMetadata(
             mbid = releaseId,
             entity = MusicBrainzEntity.RELEASE,
             forceRefresh = false,
@@ -448,7 +448,7 @@ class ImageMetadataRepositoryImplTest : KoinTest {
                 disambiguation = releaseGroupDisambiguation,
             ),
         )
-        val releaseGroupImageMetadata = repository.getImageMetadata(
+        val releaseGroupImageMetadata = repository.getAndSaveImageMetadata(
             mbid = releaseGroupId,
             entity = MusicBrainzEntity.RELEASE_GROUP,
             forceRefresh = false,

--- a/data/database/src/commonMain/kotlin/ly/david/musicsearch/data/database/dao/MbidImageDao.kt
+++ b/data/database/src/commonMain/kotlin/ly/david/musicsearch/data/database/dao/MbidImageDao.kt
@@ -38,6 +38,14 @@ class MbidImageDao(
         }
     }
 
+    override fun saveImageMetadata(mbidToImageMetadataMap: Map<String, List<ImageMetadata>>) {
+        transacter.transaction {
+            mbidToImageMetadataMap.forEach { (mbid, imageMetadataList) ->
+                saveImageMetadata(mbid, imageMetadataList)
+            }
+        }
+    }
+
     override fun getFrontImageMetadata(mbid: String): ImageMetadata? {
         return transacter.getFrontImageMetadata(
             mbid = mbid,

--- a/shared/domain/src/commonMain/kotlin/ly/david/musicsearch/shared/domain/image/ImageMetadataRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/ly/david/musicsearch/shared/domain/image/ImageMetadataRepository.kt
@@ -10,18 +10,27 @@ import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
  */
 interface ImageMetadataRepository {
     /**
-     * Returns a url to the cover art.
-     * Empty if none found.
+     * Returns metadata for an image, including its url. An image that does not exist will have an empty url.
      *
      * Also saves it to db.
      *
-     * Make sure to handle non-404 errors at call site.
+     * Appropriate for getting a single image in a details view.
      */
-    suspend fun getImageMetadata(
+    suspend fun getAndSaveImageMetadata(
         mbid: String,
         entity: MusicBrainzEntity,
         forceRefresh: Boolean,
     ): ImageMetadata
+
+    /**
+     * Saves metadata for an image, eventually. For performance reasons, we will batch the write to the database.
+     *
+     * Appropriate for getting images in a list view, where each item will contain its own image metadata.
+     */
+    suspend fun saveImageMetadata(
+        mbid: String,
+        entity: MusicBrainzEntity,
+    )
 
     fun getNumberOfImageMetadataById(mbid: String): Int
 

--- a/shared/domain/src/commonMain/kotlin/ly/david/musicsearch/shared/domain/image/ImageUrlDao.kt
+++ b/shared/domain/src/commonMain/kotlin/ly/david/musicsearch/shared/domain/image/ImageUrlDao.kt
@@ -9,6 +9,10 @@ interface ImageUrlDao {
         imageMetadataList: List<ImageMetadata>,
     )
 
+    fun saveImageMetadata(
+        mbidToImageMetadataMap: Map<String, List<ImageMetadata>>,
+    )
+
     fun getFrontImageMetadata(mbid: String): ImageMetadata?
 
     fun getAllImageMetadataById(

--- a/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/event/EventPresenter.kt
+++ b/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/event/EventPresenter.kt
@@ -99,7 +99,7 @@ internal class EventPresenter(
 
         LaunchedEffect(forceRefreshDetails, event) {
             event = event?.copy(
-                imageMetadata = imageMetadataRepository.getImageMetadata(
+                imageMetadata = imageMetadataRepository.getAndSaveImageMetadata(
                     mbid = event?.id ?: return@LaunchedEffect,
                     entity = MusicBrainzEntity.EVENT,
                     forceRefresh = forceRefreshDetails,

--- a/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/release/ReleasePresenter.kt
+++ b/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/release/ReleasePresenter.kt
@@ -120,7 +120,7 @@ internal class ReleasePresenter(
         // Image fetching was split off from details model so that we can display data before images load
         LaunchedEffect(forceRefreshDetails, release) {
             release = release?.copy(
-                imageMetadata = imageMetadataRepository.getImageMetadata(
+                imageMetadata = imageMetadataRepository.getAndSaveImageMetadata(
                     mbid = release?.id ?: return@LaunchedEffect,
                     entity = MusicBrainzEntity.RELEASE,
                     forceRefresh = forceRefreshDetails,

--- a/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/releasegroup/ReleaseGroupPresenter.kt
+++ b/shared/feature/details/src/commonMain/kotlin/ly/david/musicsearch/shared/feature/details/releasegroup/ReleaseGroupPresenter.kt
@@ -110,7 +110,7 @@ internal class ReleaseGroupPresenter(
 
         LaunchedEffect(forceRefreshDetails, releaseGroup) {
             releaseGroup = releaseGroup?.copy(
-                imageMetadata = imageMetadataRepository.getImageMetadata(
+                imageMetadata = imageMetadataRepository.getAndSaveImageMetadata(
                     mbid = releaseGroup?.id ?: return@LaunchedEffect,
                     entity = MusicBrainzEntity.RELEASE_GROUP,
                     forceRefresh = forceRefreshDetails,

--- a/shared/feature/images/src/androidUnitTest/kotlin/ly/david/musicsearch/shared/feature/images/ImagesPresenterTest.kt
+++ b/shared/feature/images/src/androidUnitTest/kotlin/ly/david/musicsearch/shared/feature/images/ImagesPresenterTest.kt
@@ -39,12 +39,19 @@ class ImagesPresenterTest {
                 get() = flowOf(ImagesSortOption.RECENTLY_ADDED)
         },
         imageMetadataRepository = object : ImageMetadataRepository {
-            override suspend fun getImageMetadata(
+            override suspend fun getAndSaveImageMetadata(
                 mbid: String,
                 entity: MusicBrainzEntity,
                 forceRefresh: Boolean,
             ): ImageMetadata {
                 return ImageMetadata()
+            }
+
+            override suspend fun saveImageMetadata(
+                mbid: String,
+                entity: MusicBrainzEntity
+            ) {
+                // No-op
             }
 
             override fun observeAllImageMetadata(

--- a/ui/common/src/commonMain/kotlin/ly/david/musicsearch/ui/common/release/ReleasesListPresenter.kt
+++ b/ui/common/src/commonMain/kotlin/ly/david/musicsearch/ui/common/release/ReleasesListPresenter.kt
@@ -61,10 +61,9 @@ class ReleasesListPresenter(
                     if (!requestedImageMetadataForIds.contains(event.entityId)) {
                         requestedImageMetadataForIds = requestedImageMetadataForIds + setOf(event.entityId)
                         scope.launch {
-                            imageMetadataRepository.getImageMetadata(
+                            imageMetadataRepository.saveImageMetadata(
                                 mbid = event.entityId,
                                 entity = MusicBrainzEntity.RELEASE,
-                                forceRefresh = false,
                             )
                         }
                     }

--- a/ui/common/src/commonMain/kotlin/ly/david/musicsearch/ui/common/releasegroup/ReleaseGroupsListPresenter.kt
+++ b/ui/common/src/commonMain/kotlin/ly/david/musicsearch/ui/common/releasegroup/ReleaseGroupsListPresenter.kt
@@ -62,10 +62,9 @@ class ReleaseGroupsListPresenter(
                     if (!requestedImageMetadataForIds.contains(event.entityId)) {
                         requestedImageMetadataForIds = requestedImageMetadataForIds + setOf(event.entityId)
                         scope.launch {
-                            imageMetadataRepository.getImageMetadata(
+                            imageMetadataRepository.saveImageMetadata(
                                 mbid = event.entityId,
                                 entity = MusicBrainzEntity.RELEASE_GROUP,
-                                forceRefresh = false,
                             )
                         }
                     }


### PR DESCRIPTION
#1413