### PR TITLE
fix: do not crash when refreshing details (due to foreign key constraint failure when entity is deleted but aliases remain); update database version to 50

### DIFF
--- a/data/database/src/commonMain/sqldelight/migrations/49.sqm
+++ b/data/database/src/commonMain/sqldelight/migrations/49.sqm
@@ -1,5 +1,65 @@
 import kotlin.Boolean;
 
+-- Migration script to add CASCADE DELETE to alias tables
+-- This script recreates all alias tables with CASCADE DELETE foreign key constraints
+
+-- Drop existing indices and view
+DROP INDEX IF EXISTS idx_work_alias_work_id;
+DROP INDEX IF EXISTS idx_work_alias_name;
+DROP INDEX IF EXISTS idx_series_alias_series_id;
+DROP INDEX IF EXISTS idx_series_alias_name;
+DROP INDEX IF EXISTS idx_release_group_alias_release_group_id;
+DROP INDEX IF EXISTS idx_release_group_alias_name;
+DROP INDEX IF EXISTS idx_release_alias_release_id;
+DROP INDEX IF EXISTS idx_release_alias_name;
+DROP INDEX IF EXISTS idx_recording_alias_recording_id;
+DROP INDEX IF EXISTS idx_recording_alias_name;
+DROP INDEX IF EXISTS idx_place_alias_place_id;
+DROP INDEX IF EXISTS idx_place_alias_name;
+DROP INDEX IF EXISTS idx_label_alias_label_id;
+DROP INDEX IF EXISTS idx_label_alias_name;
+DROP INDEX IF EXISTS idx_instrument_alias_instrument_id;
+DROP INDEX IF EXISTS idx_instrument_alias_name;
+DROP INDEX IF EXISTS idx_genre_alias_genre_id;
+DROP INDEX IF EXISTS idx_genre_alias_name;
+DROP INDEX IF EXISTS idx_event_alias_event_id;
+DROP INDEX IF EXISTS idx_event_alias_name;
+DROP INDEX IF EXISTS idx_artist_alias_artist_id;
+DROP INDEX IF EXISTS idx_artist_alias_name;
+DROP INDEX IF EXISTS idx_area_alias_area_id;
+DROP INDEX IF EXISTS idx_area_alias_name;
+
+DROP VIEW IF EXISTS all_alias_names;
+
+-- Backup tables
+CREATE TABLE area_alias_backup AS SELECT * FROM area_alias;
+CREATE TABLE artist_alias_backup AS SELECT * FROM artist_alias;
+CREATE TABLE event_alias_backup AS SELECT * FROM event_alias;
+CREATE TABLE genre_alias_backup AS SELECT * FROM genre_alias;
+CREATE TABLE instrument_alias_backup AS SELECT * FROM instrument_alias;
+CREATE TABLE label_alias_backup AS SELECT * FROM label_alias;
+CREATE TABLE place_alias_backup AS SELECT * FROM place_alias;
+CREATE TABLE recording_alias_backup AS SELECT * FROM recording_alias;
+CREATE TABLE release_alias_backup AS SELECT * FROM release_alias;
+CREATE TABLE release_group_alias_backup AS SELECT * FROM release_group_alias;
+CREATE TABLE series_alias_backup AS SELECT * FROM series_alias;
+CREATE TABLE work_alias_backup AS SELECT * FROM work_alias;
+
+-- Drop tables
+DROP TABLE IF EXISTS work_alias;
+DROP TABLE IF EXISTS series_alias;
+DROP TABLE IF EXISTS release_group_alias;
+DROP TABLE IF EXISTS release_alias;
+DROP TABLE IF EXISTS recording_alias;
+DROP TABLE IF EXISTS place_alias;
+DROP TABLE IF EXISTS label_alias;
+DROP TABLE IF EXISTS instrument_alias;
+DROP TABLE IF EXISTS genre_alias;
+DROP TABLE IF EXISTS event_alias;
+DROP TABLE IF EXISTS artist_alias;
+DROP TABLE IF EXISTS area_alias;
+
+-- Recreate tables with CASCADE DELETE foreign keys
 CREATE TABLE area_alias (
   id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   area_id TEXT NOT NULL,
@@ -156,6 +216,7 @@ CREATE TABLE work_alias (
   FOREIGN KEY (work_id) REFERENCES work(id) ON DELETE CASCADE
 );
 
+-- Recreate indices
 CREATE INDEX idx_area_alias_area_id ON area_alias(area_id);
 CREATE INDEX idx_area_alias_name ON area_alias(name);
 
@@ -192,6 +253,7 @@ CREATE INDEX idx_series_alias_name ON series_alias(name);
 CREATE INDEX idx_work_alias_work_id ON work_alias(work_id);
 CREATE INDEX idx_work_alias_name ON work_alias(name);
 
+-- Recreate the view
 CREATE VIEW all_alias_names AS
 SELECT area_id AS mbid, name FROM area_alias
 UNION ALL
@@ -217,338 +279,30 @@ SELECT series_id AS mbid, name FROM series_alias
 UNION ALL
 SELECT work_id AS mbid, name FROM work_alias;
 
-insertAreaAlias:
-INSERT INTO area_alias (
-  id,
-  area_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
+-- Restore data from backups
+INSERT INTO area_alias SELECT * FROM area_alias_backup;
+INSERT INTO artist_alias SELECT * FROM artist_alias_backup;
+INSERT INTO event_alias SELECT * FROM event_alias_backup;
+INSERT INTO genre_alias SELECT * FROM genre_alias_backup;
+INSERT INTO instrument_alias SELECT * FROM instrument_alias_backup;
+INSERT INTO label_alias SELECT * FROM label_alias_backup;
+INSERT INTO place_alias SELECT * FROM place_alias_backup;
+INSERT INTO recording_alias SELECT * FROM recording_alias_backup;
+INSERT INTO release_alias SELECT * FROM release_alias_backup;
+INSERT INTO release_group_alias SELECT * FROM release_group_alias_backup;
+INSERT INTO series_alias SELECT * FROM series_alias_backup;
+INSERT INTO work_alias SELECT * FROM work_alias_backup;
 
-deleteAreaAlias:
-DELETE FROM area_alias
-WHERE area_id = :mbid;
-
-insertArtistAlias:
-INSERT INTO artist_alias (
-  id,
-  artist_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
-
-deleteArtistAlias:
-DELETE FROM artist_alias
-WHERE artist_id = :mbid;
-
-insertEventAlias:
-INSERT INTO event_alias (
-  id,
-  event_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
-
-deleteEventAlias:
-DELETE FROM event_alias
-WHERE event_id = :mbid;
-
-insertGenreAlias:
-INSERT INTO genre_alias (
-  id,
-  genre_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
-
-deleteGenreAlias:
-DELETE FROM genre_alias
-WHERE genre_id = :mbid;
-
-insertInstrumentAlias:
-INSERT INTO instrument_alias (
-  id,
-  instrument_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
-
-deleteInstrumentAlias:
-DELETE FROM instrument_alias
-WHERE instrument_id = :mbid;
-
-insertLabelAlias:
-INSERT INTO label_alias (
-  id,
-  label_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
-
-deleteLabelAlias:
-DELETE FROM label_alias
-WHERE label_id = :mbid;
-
-insertPlaceAlias:
-INSERT INTO place_alias (
-  id,
-  place_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
-
-deletePlaceAlias:
-DELETE FROM place_alias
-WHERE place_id = :mbid;
-
-insertRecordingAlias:
-INSERT INTO recording_alias (
-  id,
-  recording_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
-
-deleteRecordingAlias:
-DELETE FROM recording_alias
-WHERE recording_id = :mbid;
-
-insertReleaseAlias:
-INSERT INTO release_alias (
-  id,
-  release_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
-
-deleteReleaseAlias:
-DELETE FROM release_alias
-WHERE release_id = :mbid;
-
-insertReleaseGroupAlias:
-INSERT INTO release_group_alias (
-  id,
-  release_group_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
-
-deleteReleaseGroupAlias:
-DELETE FROM release_group_alias
-WHERE release_group_id = :mbid;
-
-insertSeriesAlias:
-INSERT INTO series_alias (
-  id,
-  series_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
-
-deleteSeriesAlias:
-DELETE FROM series_alias
-WHERE series_id = :mbid;
-
-insertWorkAlias:
-INSERT INTO work_alias (
-  id,
-  work_id,
-  name,
-  locale,
-  type_id,
-  is_primary,
-  begin_date,
-  end_date,
-  ended
-)
-VALUES (
-  nullif(:id, 0),
-  :mbid,
-  :name,
-  :locale,
-  :typeId,
-  :isPrimary,
-  :beginDate,
-  :endDate,
-  :ended
-);
-
-deleteWorkAlias:
-DELETE FROM work_alias
-WHERE work_id = :mbid;
+-- Drop backup tables
+DROP TABLE area_alias_backup;
+DROP TABLE artist_alias_backup;
+DROP TABLE event_alias_backup;
+DROP TABLE genre_alias_backup;
+DROP TABLE instrument_alias_backup;
+DROP TABLE label_alias_backup;
+DROP TABLE place_alias_backup;
+DROP TABLE recording_alias_backup;
+DROP TABLE release_alias_backup;
+DROP TABLE release_group_alias_backup;
+DROP TABLE series_alias_backup;
+DROP TABLE work_alias_backup;

--- a/data/musicbrainz/src/commonMain/kotlin/ly/david/musicsearch/data/musicbrainz/api/LookupApi.kt
+++ b/data/musicbrainz/src/commonMain/kotlin/ly/david/musicsearch/data/musicbrainz/api/LookupApi.kt
@@ -31,7 +31,7 @@ interface LookupApi {
     suspend fun lookupArea(
         areaId: String,
 
-        include: String? = URL_REL,
+        include: String? = "$URL_REL+$ALIASES",
 
         // TODO: Separate tab: artists, events, labels, releases, recordings, places, works
         //  we might be able to do paged browse requests for these
@@ -43,37 +43,37 @@ interface LookupApi {
 
     suspend fun lookupArtist(
         artistId: String,
-        include: String? = URL_REL,
+        include: String? = "$URL_REL+$ALIASES",
     ): ArtistMusicBrainzNetworkModel
 
     suspend fun lookupEvent(
         eventId: String,
-        include: String? = URL_REL,
+        include: String? = "$URL_REL+$ALIASES",
     ): EventMusicBrainzNetworkModel
 
     suspend fun lookupGenre(
         genreId: String,
-        include: String? = URL_REL,
+        include: String? = "$URL_REL+$ALIASES",
     ): GenreMusicBrainzNetworkModel
 
     suspend fun lookupInstrument(
         instrumentId: String,
-        include: String = URL_REL,
+        include: String = "$URL_REL+$ALIASES",
     ): InstrumentMusicBrainzNetworkModel
 
     suspend fun lookupLabel(
         labelId: String,
-        include: String = URL_REL,
+        include: String = "$URL_REL+$ALIASES",
     ): LabelMusicBrainzNetworkModel
 
     suspend fun lookupPlace(
         placeId: String,
-        include: String? = URL_REL,
+        include: String? = "$URL_REL+$ALIASES",
     ): PlaceMusicBrainzNetworkModel
 
     suspend fun lookupRecording(
         recordingId: String,
-        include: String = "artist-credits+$URL_REL",
+        include: String = "artist-credits+$URL_REL+$ALIASES",
     ): RecordingMusicBrainzNetworkModel
 
     suspend fun lookupRelease(
@@ -82,22 +82,23 @@ interface LookupApi {
             "+labels" + // gives us labels (alternatively, we can get them from rels)
             "+recordings" + // gives us tracks
             "+release-groups" + // gives us types
-            "+$URL_REL",
+            "+$URL_REL" +
+            "+$ALIASES",
     ): ReleaseMusicBrainzNetworkModel
 
     suspend fun lookupReleaseGroup(
         releaseGroupId: String,
-        include: String = "artists+$URL_REL", // "releases+artists+media"
+        include: String = "artists+$URL_REL+$ALIASES", // "releases+artists+media"
     ): ReleaseGroupMusicBrainzNetworkModel
 
     suspend fun lookupSeries(
         seriesId: String,
-        include: String? = URL_REL,
+        include: String? = "$URL_REL+$ALIASES",
     ): SeriesMusicBrainzNetworkModel
 
     suspend fun lookupWork(
         workId: String,
-        include: String? = URL_REL,
+        include: String? = "$URL_REL+$ALIASES",
     ): WorkMusicBrainzNetworkModel
 }
 

--- a/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/area/AreaRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/area/AreaRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.area
 
 import kotlinx.datetime.Instant
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.musicbrainz.api.LookupApi
 import ly.david.musicsearch.data.musicbrainz.models.core.AreaMusicBrainzNetworkModel
@@ -12,6 +13,7 @@ import ly.david.musicsearch.shared.domain.relation.RelationRepository
 class AreaRepositoryImpl(
     private val areaDao: AreaDao,
     private val relationRepository: RelationRepository,
+    private val aliasDao: AliasDao,
     private val lookupApi: LookupApi,
 ) : AreaRepository {
 
@@ -65,6 +67,8 @@ class AreaRepositoryImpl(
                     type = area.type ?: "",
                 ),
             )
+
+            aliasDao.insertReplaceAll(listOf(area))
 
             val relationWithOrderList = area.relations.toRelationWithOrderList(area.id)
             relationRepository.insertAllUrlRelations(

--- a/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/artist/ArtistRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/artist/ArtistRepositoryImpl.kt
@@ -1,12 +1,15 @@
 package ly.david.musicsearch.data.repository.artist
 
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.database.dao.ArtistDao
 import ly.david.musicsearch.data.musicbrainz.api.LookupApi
 import ly.david.musicsearch.data.musicbrainz.models.core.ArtistMusicBrainzNetworkModel
 import ly.david.musicsearch.data.repository.internal.toRelationWithOrderList
 import ly.david.musicsearch.shared.domain.artist.ArtistRepository
+import ly.david.musicsearch.shared.domain.coroutine.CoroutineDispatchers
 import ly.david.musicsearch.shared.domain.details.ArtistDetailsModel
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
 import ly.david.musicsearch.shared.domain.relation.RelationRepository
@@ -15,14 +18,16 @@ class ArtistRepositoryImpl(
     private val artistDao: ArtistDao,
     private val relationRepository: RelationRepository,
     private val areaDao: AreaDao,
+    private val aliasDao: AliasDao,
     private val lookupApi: LookupApi,
+    private val coroutineDispatchers: CoroutineDispatchers,
 ) : ArtistRepository {
 
     override suspend fun lookupArtist(
         artistId: String,
         forceRefresh: Boolean,
         lastUpdated: Instant,
-    ): ArtistDetailsModel {
+    ): ArtistDetailsModel = withContext(coroutineDispatchers.io) {
         if (forceRefresh) {
             delete(artistId)
         }
@@ -39,7 +44,7 @@ class ArtistRepositoryImpl(
             val artistWithUrls = artistDetailsModel.copy(
                 urls = urlRelations,
             )
-            return artistWithUrls
+            return@withContext artistWithUrls
         }
 
         val artistMusicBrainzModel = lookupApi.lookupArtist(artistId)
@@ -47,7 +52,7 @@ class ArtistRepositoryImpl(
             artist = artistMusicBrainzModel,
             lastUpdated = lastUpdated,
         )
-        return lookupArtist(
+        return@withContext lookupArtist(
             artistId = artistId,
             forceRefresh = false,
             lastUpdated = lastUpdated,
@@ -70,6 +75,9 @@ class ArtistRepositoryImpl(
     ) {
         artistDao.withTransaction {
             artistDao.insertReplace(artist)
+
+            aliasDao.insertReplaceAll(listOf(artist))
+
             artist.area?.let { area ->
                 areaDao.insert(area)
             }

--- a/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/event/EventRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/event/EventRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.event
 
 import kotlinx.datetime.Instant
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.EventDao
 import ly.david.musicsearch.data.musicbrainz.api.LookupApi
 import ly.david.musicsearch.data.musicbrainz.models.core.EventMusicBrainzNetworkModel
@@ -12,6 +13,7 @@ import ly.david.musicsearch.shared.domain.relation.RelationRepository
 class EventRepositoryImpl(
     private val eventDao: EventDao,
     private val relationRepository: RelationRepository,
+    private val aliasDao: AliasDao,
     private val lookupApi: LookupApi,
 ) : EventRepository {
 
@@ -61,6 +63,8 @@ class EventRepositoryImpl(
     ) {
         eventDao.withTransaction {
             eventDao.insert(event)
+
+            aliasDao.insertReplaceAll(listOf(event))
 
             val relationWithOrderList = event.relations.toRelationWithOrderList(event.id)
             relationRepository.insertAllUrlRelations(

--- a/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/instrument/InstrumentRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/instrument/InstrumentRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.instrument
 
 import kotlinx.datetime.Instant
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.InstrumentDao
 import ly.david.musicsearch.data.musicbrainz.api.LookupApi
 import ly.david.musicsearch.data.musicbrainz.models.core.InstrumentMusicBrainzNetworkModel
@@ -12,6 +13,7 @@ import ly.david.musicsearch.shared.domain.relation.RelationRepository
 class InstrumentRepositoryImpl(
     private val instrumentDao: InstrumentDao,
     private val relationRepository: RelationRepository,
+    private val aliasDao: AliasDao,
     private val lookupApi: LookupApi,
 ) : InstrumentRepository {
 
@@ -56,6 +58,8 @@ class InstrumentRepositoryImpl(
     ) {
         instrumentDao.withTransaction {
             instrumentDao.insert(instrument)
+
+            aliasDao.insertReplaceAll(listOf(instrument))
 
             val relationWithOrderList = instrument.relations.toRelationWithOrderList(instrument.id)
             relationRepository.insertAllUrlRelations(

--- a/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/label/LabelRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/label/LabelRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.label
 
 import kotlinx.datetime.Instant
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.LabelDao
 import ly.david.musicsearch.data.musicbrainz.api.LookupApi
 import ly.david.musicsearch.data.musicbrainz.models.core.LabelMusicBrainzNetworkModel
@@ -12,6 +13,7 @@ import ly.david.musicsearch.shared.domain.relation.RelationRepository
 class LabelRepositoryImpl(
     private val labelDao: LabelDao,
     private val relationRepository: RelationRepository,
+    private val aliasDao: AliasDao,
     private val lookupApi: LookupApi,
 ) : LabelRepository {
 
@@ -56,6 +58,8 @@ class LabelRepositoryImpl(
     ) {
         labelDao.withTransaction {
             labelDao.insert(label)
+
+            aliasDao.insertReplaceAll(listOf(label))
 
             val relationWithOrderList = label.relations.toRelationWithOrderList(label.id)
             relationRepository.insertAllUrlRelations(

--- a/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/place/PlaceRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/place/PlaceRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.place
 
 import kotlinx.datetime.Instant
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.database.dao.PlaceDao
 import ly.david.musicsearch.data.musicbrainz.api.LookupApi
@@ -14,6 +15,7 @@ class PlaceRepositoryImpl(
     private val placeDao: PlaceDao,
     private val areaDao: AreaDao,
     private val relationRepository: RelationRepository,
+    private val aliasDao: AliasDao,
     private val lookupApi: LookupApi,
 ) : PlaceRepository {
 
@@ -66,6 +68,9 @@ class PlaceRepositoryImpl(
     ) {
         placeDao.withTransaction {
             placeDao.insert(place)
+
+            aliasDao.insertReplaceAll(listOf(place))
+
             place.area?.let { areaMusicBrainzModel ->
                 areaDao.insert(areaMusicBrainzModel)
                 placeDao.insertPlaceByArea(

--- a/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/recording/RecordingRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/recording/RecordingRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.recording
 
 import kotlinx.datetime.Instant
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.ArtistCreditDao
 import ly.david.musicsearch.data.database.dao.RecordingDao
 import ly.david.musicsearch.data.musicbrainz.api.LookupApi
@@ -14,6 +15,7 @@ class RecordingRepositoryImpl(
     private val recordingDao: RecordingDao,
     private val artistCreditDao: ArtistCreditDao,
     private val relationRepository: RelationRepository,
+    private val aliasDao: AliasDao,
     private val lookupApi: LookupApi,
 ) : RecordingRepository {
 
@@ -71,6 +73,8 @@ class RecordingRepositoryImpl(
     ) {
         recordingDao.withTransaction {
             recordingDao.insert(recording)
+
+            aliasDao.insertReplaceAll(listOf(recording))
 
             val relationWithOrderList = recording.relations.toRelationWithOrderList(recording.id)
             relationRepository.insertAllUrlRelations(

--- a/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/release/ReleaseRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/release/ReleaseRepositoryImpl.kt
@@ -9,6 +9,7 @@ import app.cash.paging.map
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.database.dao.ArtistCreditDao
 import ly.david.musicsearch.data.database.dao.LabelDao
@@ -46,6 +47,7 @@ class ReleaseRepositoryImpl(
     private val relationRepository: RelationRepository,
     private val mediumDao: MediumDao,
     private val trackDao: TrackDao,
+    private val aliasDao: AliasDao,
     private val lookupApi: LookupApi,
 ) : ReleaseRepository {
 
@@ -127,6 +129,8 @@ class ReleaseRepositoryImpl(
                 )
             }
             releaseDao.insert(release)
+
+            aliasDao.insertReplaceAll(listOf(release))
 
             // This serves as a replacement for browsing labels by release.
             // Unless we find a release that has more than 25 labels, we don't need to browse for labels.

--- a/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/releasegroup/ReleaseGroupRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/releasegroup/ReleaseGroupRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.releasegroup
 
 import kotlinx.datetime.Instant
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.ArtistCreditDao
 import ly.david.musicsearch.data.database.dao.ReleaseGroupDao
 import ly.david.musicsearch.data.musicbrainz.api.LookupApi
@@ -14,6 +15,7 @@ class ReleaseGroupRepositoryImpl(
     private val releaseGroupDao: ReleaseGroupDao,
     private val artistCreditDao: ArtistCreditDao,
     private val relationRepository: RelationRepository,
+    private val aliasDao: AliasDao,
     private val lookupApi: LookupApi,
 ) : ReleaseGroupRepository {
 
@@ -69,6 +71,8 @@ class ReleaseGroupRepositoryImpl(
     ) {
         releaseGroupDao.withTransaction {
             releaseGroupDao.insertReleaseGroup(releaseGroup)
+
+            aliasDao.insertReplaceAll(listOf(releaseGroup))
 
             val relationWithOrderList = releaseGroup.relations.toRelationWithOrderList(releaseGroup.id)
             relationRepository.insertAllUrlRelations(

--- a/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/series/SeriesRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/series/SeriesRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.series
 
 import kotlinx.datetime.Instant
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.SeriesDao
 import ly.david.musicsearch.data.musicbrainz.api.LookupApi
 import ly.david.musicsearch.data.musicbrainz.models.core.SeriesMusicBrainzNetworkModel
@@ -12,6 +13,7 @@ import ly.david.musicsearch.shared.domain.series.SeriesRepository
 class SeriesRepositoryImpl(
     private val seriesDao: SeriesDao,
     private val relationRepository: RelationRepository,
+    private val aliasDao: AliasDao,
     private val lookupApi: LookupApi,
 ) : SeriesRepository {
 
@@ -61,6 +63,8 @@ class SeriesRepositoryImpl(
     ) {
         seriesDao.withTransaction {
             seriesDao.insert(series)
+
+            aliasDao.insertReplaceAll(listOf(series))
 
             val relationWithOrderList = series.relations.toRelationWithOrderList(series.id)
             relationRepository.insertAllUrlRelations(

--- a/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/work/WorkRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/ly/david/musicsearch/data/repository/work/WorkRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.work
 
 import kotlinx.datetime.Instant
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.WorkAttributeDao
 import ly.david.musicsearch.data.database.dao.WorkDao
 import ly.david.musicsearch.data.musicbrainz.api.LookupApi
@@ -14,6 +15,7 @@ class WorkRepositoryImpl(
     private val workDao: WorkDao,
     private val workAttributeDao: WorkAttributeDao,
     private val relationRepository: RelationRepository,
+    private val aliasDao: AliasDao,
     private val lookupApi: LookupApi,
 ) : WorkRepository {
 
@@ -66,6 +68,8 @@ class WorkRepositoryImpl(
                 workId = work.id,
                 work.attributes,
             )
+
+            aliasDao.insertReplaceAll(listOf(work))
 
             val relationWithOrderList = work.relations.toRelationWithOrderList(work.id)
             relationRepository.insertAllUrlRelations(

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/area/AreaRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/area/AreaRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package ly.david.musicsearch.data.repository.area
 
 import kotlinx.coroutines.test.runTest
 import ly.david.data.test.KoinTestRule
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
@@ -27,6 +28,7 @@ class AreaRepositoryImplTest : KoinTest, TestAreaRepository {
     override val detailsMetadataDao: DetailsMetadataDao by inject()
     override val relationDao: RelationDao by inject()
     override val areaDao: AreaDao by inject()
+    override val aliasDao: AliasDao by inject()
 
     @Test
     fun `lookup is cached, and force refresh invalidates cache`() = runTest {

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/artist/ArtistCollaborationRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/artist/ArtistCollaborationRepositoryImplTest.kt
@@ -22,6 +22,7 @@ import ly.david.musicsearch.data.repository.helpers.testDateTimeInThePast
 import ly.david.musicsearch.shared.domain.BrowseMethod
 import ly.david.musicsearch.shared.domain.ListFilters
 import ly.david.musicsearch.shared.domain.artist.CollaboratingArtistAndEntity
+import ly.david.musicsearch.shared.domain.coroutine.CoroutineDispatchers
 import ly.david.musicsearch.shared.domain.history.DetailsMetadataDao
 import ly.david.musicsearch.shared.domain.network.MusicBrainzEntity
 import org.junit.Assert.assertEquals
@@ -48,6 +49,7 @@ class ArtistCollaborationRepositoryImplTest :
     override val collectionEntityDao: CollectionEntityDao by inject()
     override val recordingDao: RecordingDao by inject()
     override val aliasDao: AliasDao by inject()
+    override val coroutineDispatchers: CoroutineDispatchers by inject()
 
     @Test
     fun `lookup artist, then recordings, releases, release groups, and collaborations`() = runTest {

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/artist/ArtistRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/artist/ArtistRepositoryImplTest.kt
@@ -23,6 +23,7 @@ import ly.david.musicsearch.data.repository.helpers.testDateTimeInThePast
 import ly.david.musicsearch.shared.domain.BrowseMethod
 import ly.david.musicsearch.shared.domain.LifeSpanUiModel
 import ly.david.musicsearch.shared.domain.ListFilters
+import ly.david.musicsearch.shared.domain.coroutine.CoroutineDispatchers
 import ly.david.musicsearch.shared.domain.details.ArtistDetailsModel
 import ly.david.musicsearch.shared.domain.history.DetailsMetadataDao
 import ly.david.musicsearch.shared.domain.listitem.AreaListItemModel
@@ -46,8 +47,9 @@ class ArtistRepositoryImplTest : KoinTest, TestArtistRepository {
     override val relationDao: RelationDao by inject()
     override val areaDao: AreaDao by inject()
     override val browseRemoteMetadataDao: BrowseRemoteMetadataDao by inject()
+    override val aliasDao: AliasDao by inject()
+    override val coroutineDispatchers: CoroutineDispatchers by inject()
     private val collectionEntityDao: CollectionEntityDao by inject()
-    private val aliasDao: AliasDao by inject()
 
     @Test
     fun `lookup artist`() = runTest {

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/artist/ArtistsListRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/artist/ArtistsListRepositoryImplTest.kt
@@ -31,6 +31,7 @@ import ly.david.musicsearch.shared.domain.BrowseMethod
 import ly.david.musicsearch.shared.domain.LifeSpanUiModel
 import ly.david.musicsearch.shared.domain.ListFilters
 import ly.david.musicsearch.shared.domain.artist.ArtistsListRepository
+import ly.david.musicsearch.shared.domain.coroutine.CoroutineDispatchers
 import ly.david.musicsearch.shared.domain.details.ArtistDetailsModel
 import ly.david.musicsearch.shared.domain.history.DetailsMetadataDao
 import ly.david.musicsearch.shared.domain.listitem.ArtistListItemModel
@@ -53,9 +54,10 @@ class ArtistsListRepositoryImplTest : KoinTest, TestArtistRepository {
     override val relationsMetadataDao: RelationsMetadataDao by inject()
     override val relationDao: RelationDao by inject()
     override val detailsMetadataDao: DetailsMetadataDao by inject()
+    override val aliasDao: AliasDao by inject()
+    override val coroutineDispatchers: CoroutineDispatchers by inject()
     private val collectionDao: CollectionDao by inject()
     private val collectionEntityDao: CollectionEntityDao by inject()
-    private val aliasDao: AliasDao by inject()
 
     private fun createArtistsListRepository(
         artists: List<ArtistMusicBrainzNetworkModel>,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/event/EventRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/event/EventRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package ly.david.musicsearch.data.repository.event
 
 import kotlinx.coroutines.test.runTest
 import ly.david.data.test.KoinTestRule
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.EventDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
@@ -36,6 +37,7 @@ class EventRepositoryImplTest : KoinTest, IEventRepositoryImplTest, TestEventRep
     override val detailsMetadataDao: DetailsMetadataDao by inject()
     override val relationDao: RelationDao by inject()
     override val eventDao: EventDao by inject()
+    override val aliasDao: AliasDao by inject()
 
     @Test
     fun `lookup is cached, and force refresh invalidates cache`() = runTest {

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/event/EventsListRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/event/EventsListRepositoryImplTest.kt
@@ -52,10 +52,10 @@ class EventsListRepositoryImplTest : KoinTest, TestEventRepository {
     override val relationsMetadataDao: RelationsMetadataDao by inject()
     override val detailsMetadataDao: DetailsMetadataDao by inject()
     override val relationDao: RelationDao by inject()
+    override val aliasDao: AliasDao by inject()
     private val collectionDao: CollectionDao by inject()
     private val browseRemoteMetadataDao: BrowseRemoteMetadataDao by inject()
     private val collectionEntityDao: CollectionEntityDao by inject()
-    private val aliasDao: AliasDao by inject()
 
     private fun createEventsListRepository(
         events: List<EventMusicBrainzNetworkModel>,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestAreaRepository.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestAreaRepository.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.helpers
 
 import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
@@ -15,6 +16,7 @@ interface TestAreaRepository {
     val detailsMetadataDao: DetailsMetadataDao
     val relationDao: RelationDao
     val areaDao: AreaDao
+    val aliasDao: AliasDao
 
     /**
      * This builds [AreaRepositoryImpl] cast as [AreaRepository].
@@ -39,6 +41,7 @@ interface TestAreaRepository {
         return AreaRepositoryImpl(
             areaDao = areaDao,
             relationRepository = relationRepository,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupArea(
                     areaId: String,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestArtistRepository.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestArtistRepository.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.helpers
 
 import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.database.dao.ArtistDao
 import ly.david.musicsearch.data.database.dao.BrowseRemoteMetadataDao
@@ -10,6 +11,7 @@ import ly.david.musicsearch.data.musicbrainz.models.core.ArtistMusicBrainzNetwor
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
 import ly.david.musicsearch.data.repository.artist.ArtistRepositoryImpl
 import ly.david.musicsearch.shared.domain.artist.ArtistRepository
+import ly.david.musicsearch.shared.domain.coroutine.CoroutineDispatchers
 import ly.david.musicsearch.shared.domain.history.DetailsMetadataDao
 
 interface TestArtistRepository {
@@ -19,6 +21,8 @@ interface TestArtistRepository {
     val relationDao: RelationDao
     val areaDao: AreaDao
     val browseRemoteMetadataDao: BrowseRemoteMetadataDao
+    val aliasDao: AliasDao
+    val coroutineDispatchers: CoroutineDispatchers
 
     fun createArtistRepository(
         artistMusicBrainzModel: ArtistMusicBrainzNetworkModel,
@@ -40,6 +44,7 @@ interface TestArtistRepository {
             artistDao = artistDao,
             relationRepository = relationRepository,
             areaDao = areaDao,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupArtist(
                     artistId: String,
@@ -48,6 +53,7 @@ interface TestArtistRepository {
                     return artistMusicBrainzModel
                 }
             },
+            coroutineDispatchers = coroutineDispatchers,
         )
     }
 }

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestEventRepository.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestEventRepository.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.helpers
 
 import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.EventDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
@@ -15,6 +16,7 @@ interface TestEventRepository {
     val detailsMetadataDao: DetailsMetadataDao
     val relationDao: RelationDao
     val eventDao: EventDao
+    val aliasDao: AliasDao
 
     fun createEventRepository(
         musicBrainzModel: EventMusicBrainzNetworkModel,
@@ -35,6 +37,7 @@ interface TestEventRepository {
         return EventRepositoryImpl(
             eventDao = eventDao,
             relationRepository = relationRepository,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupEvent(
                     eventId: String,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestLabelRepository.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestLabelRepository.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.helpers
 
 import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.LabelDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
@@ -16,6 +17,7 @@ interface TestLabelRepository {
     val detailsMetadataDao: DetailsMetadataDao
     val relationDao: RelationDao
     val labelDao: LabelDao
+    val aliasDao: AliasDao
 
     fun createLabelRepository(
         musicBrainzModel: LabelMusicBrainzNetworkModel,
@@ -36,6 +38,7 @@ interface TestLabelRepository {
         return LabelRepositoryImpl(
             labelDao = labelDao,
             relationRepository = relationRepository,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupLabel(
                     labelId: String,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestMusicBrainzImageMetadataRepository.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestMusicBrainzImageMetadataRepository.kt
@@ -1,4 +1,4 @@
-package ly.david.musicsearch.data.repository.he
+package ly.david.musicsearch.data.repository.helpers
 
 import kotlinx.coroutines.test.TestScope
 import ly.david.data.test.api.NoOpCoverArtArchiveApi

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestPlaceRepository.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestPlaceRepository.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.helpers
 
 import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.database.dao.BrowseRemoteMetadataDao
 import ly.david.musicsearch.data.database.dao.CollectionEntityDao
@@ -21,6 +22,7 @@ interface TestPlaceRepository {
     val areaDao: AreaDao
     val browseRemoteMetadataDao: BrowseRemoteMetadataDao
     val collectionEntityDao: CollectionEntityDao
+    val aliasDao: AliasDao
 
     fun createPlaceRepository(
         musicBrainzModel: PlaceMusicBrainzNetworkModel,
@@ -42,6 +44,7 @@ interface TestPlaceRepository {
             placeDao = this.placeDao,
             areaDao = areaDao,
             relationRepository = relationRepository,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupPlace(
                     placeId: String,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestRecordingRepository.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestRecordingRepository.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.helpers
 
 import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.ArtistCreditDao
 import ly.david.musicsearch.data.database.dao.RecordingDao
 import ly.david.musicsearch.data.database.dao.RelationDao
@@ -17,6 +18,7 @@ interface TestRecordingRepository {
     val relationDao: RelationDao
     val recordingDao: RecordingDao
     val artistCreditDao: ArtistCreditDao
+    val aliasDao: AliasDao
 
     fun createRecordingRepository(
         musicBrainzModel: RecordingMusicBrainzNetworkModel,
@@ -38,6 +40,7 @@ interface TestRecordingRepository {
             recordingDao = recordingDao,
             relationRepository = relationRepository,
             artistCreditDao = artistCreditDao,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupRecording(
                     recordingId: String,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestReleaseGroupRepository.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestReleaseGroupRepository.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.helpers
 
 import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.ArtistCreditDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
@@ -17,6 +18,8 @@ interface TestReleaseGroupRepository {
     val relationsMetadataDao: RelationsMetadataDao
     val detailsMetadataDao: DetailsMetadataDao
     val relationDao: RelationDao
+    val aliasDao: AliasDao
+
     fun createReleaseGroupRepository(
         musicBrainzModel: ReleaseGroupMusicBrainzNetworkModel,
     ): ReleaseGroupRepository {
@@ -37,6 +40,7 @@ interface TestReleaseGroupRepository {
             releaseGroupDao = releaseGroupDao,
             artistCreditDao = artistCreditDao,
             relationRepository = relationRepository,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupReleaseGroup(
                     releaseGroupId: String,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestReleaseRepository.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestReleaseRepository.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.helpers
 
 import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.database.dao.ArtistCreditDao
 import ly.david.musicsearch.data.database.dao.LabelDao
@@ -30,6 +31,7 @@ interface TestReleaseRepository {
     val relationsMetadataDao: RelationsMetadataDao
     val detailsMetadataDao: DetailsMetadataDao
     val relationDao: RelationDao
+    val aliasDao: AliasDao
 
     fun createReleaseRepository(
         musicBrainzModel: ReleaseMusicBrainzNetworkModel,
@@ -57,6 +59,7 @@ interface TestReleaseRepository {
             relationRepository = relationRepository,
             mediumDao = mediumDao,
             trackDao = trackDao,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupRelease(
                     releaseId: String,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestWorkRepository.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/helpers/TestWorkRepository.kt
@@ -1,6 +1,7 @@
 package ly.david.musicsearch.data.repository.helpers
 
 import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
 import ly.david.musicsearch.data.database.dao.WorkAttributeDao
@@ -17,6 +18,7 @@ interface TestWorkRepository {
     val relationDao: RelationDao
     val workDao: WorkDao
     val workAttributeDao: WorkAttributeDao
+    val aliasDao: AliasDao
 
     fun createWorkRepository(
         musicBrainzModel: WorkMusicBrainzNetworkModel,
@@ -38,6 +40,7 @@ interface TestWorkRepository {
             workDao = workDao,
             workAttributeDao = workAttributeDao,
             relationRepository = relationRepository,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupWork(
                     workId: String,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/image/ImageMetadataRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/image/ImageMetadataRepositoryImplTest.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import ly.david.data.test.KoinTestRule
-import ly.david.musicsearch.shared.domain.coroutine.CoroutineDispatchers
 import ly.david.musicsearch.data.coverart.api.CoverArtUrls
 import ly.david.musicsearch.data.coverart.api.ThumbnailsUrls
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.database.dao.ArtistCreditDao
 import ly.david.musicsearch.data.database.dao.EventDao
@@ -27,11 +27,12 @@ import ly.david.musicsearch.data.musicbrainz.models.core.ArtistMusicBrainzNetwor
 import ly.david.musicsearch.data.musicbrainz.models.core.EventMusicBrainzNetworkModel
 import ly.david.musicsearch.data.musicbrainz.models.core.ReleaseGroupMusicBrainzNetworkModel
 import ly.david.musicsearch.data.musicbrainz.models.core.ReleaseMusicBrainzNetworkModel
-import ly.david.musicsearch.data.repository.he.TestMusicBrainzImageMetadataRepository
 import ly.david.musicsearch.data.repository.helpers.TestEventRepository
+import ly.david.musicsearch.data.repository.helpers.TestMusicBrainzImageMetadataRepository
 import ly.david.musicsearch.data.repository.helpers.TestReleaseGroupRepository
 import ly.david.musicsearch.data.repository.helpers.TestReleaseRepository
 import ly.david.musicsearch.data.repository.helpers.testDateTimeInThePast
+import ly.david.musicsearch.shared.domain.coroutine.CoroutineDispatchers
 import ly.david.musicsearch.shared.domain.history.DetailsMetadataDao
 import ly.david.musicsearch.shared.domain.image.ImageId
 import ly.david.musicsearch.shared.domain.image.ImageMetadata
@@ -74,6 +75,7 @@ class ImageMetadataRepositoryImplTest :
     override val labelDao: LabelDao by inject()
     override val mediumDao: MediumDao by inject()
     override val trackDao: TrackDao by inject()
+    override val aliasDao: AliasDao by inject()
 
     @Test
     fun empty() = runTest {

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/instrument/InstrumentRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/instrument/InstrumentRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package ly.david.musicsearch.data.repository.instrument
 import kotlinx.coroutines.test.runTest
 import ly.david.data.test.KoinTestRule
 import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.InstrumentDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
@@ -34,6 +35,7 @@ class InstrumentRepositoryImplTest : KoinTest {
     private val detailsMetadataDao: DetailsMetadataDao by inject()
     private val relationDao: RelationDao by inject()
     private val instrumentDao: InstrumentDao by inject()
+    private val aliasDao: AliasDao by inject()
 
     private fun createRepository(
         musicBrainzModel: InstrumentMusicBrainzNetworkModel,
@@ -54,6 +56,7 @@ class InstrumentRepositoryImplTest : KoinTest {
         return InstrumentRepositoryImpl(
             instrumentDao = instrumentDao,
             relationRepository = relationRepository,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupInstrument(
                     instrumentId: String,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/label/LabelRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/label/LabelRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package ly.david.musicsearch.data.repository.label
 
 import kotlinx.coroutines.test.runTest
 import ly.david.data.test.KoinTestRule
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.LabelDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
@@ -35,6 +36,7 @@ class LabelRepositoryImplTest : KoinTest, TestLabelRepository {
     override val detailsMetadataDao: DetailsMetadataDao by inject()
     override val relationDao: RelationDao by inject()
     override val labelDao: LabelDao by inject()
+    override val aliasDao: AliasDao by inject()
 
     @Test
     fun `lookup is cached, and force refresh invalidates cache`() = runTest {

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/place/PlaceRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/place/PlaceRepositoryImplTest.kt
@@ -56,7 +56,7 @@ class PlaceRepositoryImplTest : KoinTest, TestPlaceRepository {
     override val areaDao: AreaDao by inject()
     override val browseRemoteMetadataDao: BrowseRemoteMetadataDao by inject()
     override val collectionEntityDao: CollectionEntityDao by inject()
-    private val aliasDao: AliasDao by inject()
+    override val aliasDao: AliasDao by inject()
 
     private fun createAreaRepositoryWithFakeNetworkData(
         musicBrainzModel: AreaMusicBrainzNetworkModel,
@@ -77,6 +77,7 @@ class PlaceRepositoryImplTest : KoinTest, TestPlaceRepository {
         return AreaRepositoryImpl(
             areaDao = areaDao,
             relationRepository = relationRepository,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupArea(
                     areaId: String,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/place/PlacesListRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/place/PlacesListRepositoryImplTest.kt
@@ -53,10 +53,10 @@ class PlacesListRepositoryImplTest : KoinTest, TestPlaceRepository {
     override val relationsMetadataDao: RelationsMetadataDao by inject()
     override val detailsMetadataDao: DetailsMetadataDao by inject()
     override val relationDao: RelationDao by inject()
-    private val collectionDao: CollectionDao by inject()
     override val browseRemoteMetadataDao: BrowseRemoteMetadataDao by inject()
     override val collectionEntityDao: CollectionEntityDao by inject()
-    private val aliasDao: AliasDao by inject()
+    override val aliasDao: AliasDao by inject()
+    private val collectionDao: CollectionDao by inject()
 
     private fun createPlacesListRepository(
         places: List<PlaceMusicBrainzNetworkModel>,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/recording/RecordingRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/recording/RecordingRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package ly.david.musicsearch.data.repository.recording
 
 import kotlinx.coroutines.test.runTest
 import ly.david.data.test.KoinTestRule
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.ArtistCreditDao
 import ly.david.musicsearch.data.database.dao.RecordingDao
 import ly.david.musicsearch.data.database.dao.RelationDao
@@ -37,6 +38,7 @@ class RecordingRepositoryImplTest : KoinTest, TestRecordingRepository {
     override val relationDao: RelationDao by inject()
     override val recordingDao: RecordingDao by inject()
     override val artistCreditDao: ArtistCreditDao by inject()
+    override val aliasDao: AliasDao by inject()
 
     @Test
     fun `lookup is cached, and force refresh invalidates cache`() = runTest {

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/relation/RelationRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/relation/RelationRepositoryImplTest.kt
@@ -5,9 +5,9 @@ import kotlinx.coroutines.test.runTest
 import ly.david.data.test.KoinTestRule
 import ly.david.data.test.api.FakeLookupApi
 import ly.david.data.test.zutomayoArtistMusicBrainzNetworkModel
-import ly.david.musicsearch.shared.domain.coroutine.CoroutineDispatchers
 import ly.david.musicsearch.data.coverart.api.CoverArtUrls
 import ly.david.musicsearch.data.coverart.api.ThumbnailsUrls
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.database.dao.ArtistCreditDao
 import ly.david.musicsearch.data.database.dao.LabelDao
@@ -31,9 +31,10 @@ import ly.david.musicsearch.data.musicbrainz.models.relation.Direction
 import ly.david.musicsearch.data.musicbrainz.models.relation.RelationMusicBrainzModel
 import ly.david.musicsearch.data.musicbrainz.models.relation.SerializableMusicBrainzEntity
 import ly.david.musicsearch.data.repository.RelationRepositoryImpl
-import ly.david.musicsearch.data.repository.he.TestMusicBrainzImageMetadataRepository
+import ly.david.musicsearch.data.repository.helpers.TestMusicBrainzImageMetadataRepository
 import ly.david.musicsearch.data.repository.helpers.TestReleaseRepository
 import ly.david.musicsearch.data.repository.helpers.testDateTimeInThePast
+import ly.david.musicsearch.shared.domain.coroutine.CoroutineDispatchers
 import ly.david.musicsearch.shared.domain.history.DetailsMetadataDao
 import ly.david.musicsearch.shared.domain.image.ImageId
 import ly.david.musicsearch.shared.domain.image.ImageUrlDao
@@ -67,6 +68,7 @@ class RelationRepositoryImplTest :
     override val detailsMetadataDao: DetailsMetadataDao by inject()
     override val relationDao: RelationDao by inject()
     override val imageUrlDao: ImageUrlDao by inject()
+    override val aliasDao: AliasDao by inject()
     override val coroutineDispatchers: CoroutineDispatchers by inject()
 
     private fun createRepository(

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/release/ReleaseRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/release/ReleaseRepositoryImplTest.kt
@@ -6,6 +6,7 @@ import ly.david.data.test.KoinTestRule
 import ly.david.data.test.releaseWith3CatalogNumbersWithSameLabel
 import ly.david.data.test.releaseWithSameCatalogNumberWithDifferentLabels
 import ly.david.data.test.utaNoUtaReleaseGroupMusicBrainzModel
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.AreaDao
 import ly.david.musicsearch.data.database.dao.ArtistCreditDao
 import ly.david.musicsearch.data.database.dao.LabelDao
@@ -71,6 +72,7 @@ class ReleaseRepositoryImplTest : KoinTest, TestReleaseRepository {
     override val relationsMetadataDao: RelationsMetadataDao by inject()
     override val detailsMetadataDao: DetailsMetadataDao by inject()
     override val relationDao: RelationDao by inject()
+    override val aliasDao: AliasDao by inject()
 
     @Test
     fun `lookup is cached, and force refresh invalidates cache`() = runTest {

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/release/ReleasesListRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/release/ReleasesListRepositoryImplTest.kt
@@ -58,6 +58,7 @@ import ly.david.musicsearch.data.repository.helpers.testFilter
 import ly.david.musicsearch.shared.domain.BrowseMethod
 import ly.david.musicsearch.shared.domain.ListFilters
 import ly.david.musicsearch.shared.domain.artist.ArtistCreditUiModel
+import ly.david.musicsearch.shared.domain.coroutine.CoroutineDispatchers
 import ly.david.musicsearch.shared.domain.details.ReleaseDetailsModel
 import ly.david.musicsearch.shared.domain.history.DetailsMetadataDao
 import ly.david.musicsearch.shared.domain.image.ImageId
@@ -104,7 +105,8 @@ class ReleasesListRepositoryImplTest :
     override val relationDao: RelationDao by inject()
     override val recordingDao: RecordingDao by inject()
     override val areaDao: AreaDao by inject()
-    private val aliasDao: AliasDao by inject()
+    override val aliasDao: AliasDao by inject()
+    override val coroutineDispatchers: CoroutineDispatchers by inject()
 
     private fun createReleasesListRepository(
         releases: List<ReleaseMusicBrainzNetworkModel>,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/releasegroup/ReleaseGroupRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/releasegroup/ReleaseGroupRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package ly.david.musicsearch.data.repository.releasegroup
 
 import kotlinx.coroutines.test.runTest
 import ly.david.data.test.KoinTestRule
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.ArtistCreditDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
@@ -36,6 +37,7 @@ class ReleaseGroupRepositoryImplTest : KoinTest, TestReleaseGroupRepository {
     override val relationsMetadataDao: RelationsMetadataDao by inject()
     override val detailsMetadataDao: DetailsMetadataDao by inject()
     override val relationDao: RelationDao by inject()
+    override val aliasDao: AliasDao by inject()
 
     @Test
     fun `lookup is cached, and force refresh invalidates cache`() = runTest {

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/releasegroup/ReleaseGroupsListRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/releasegroup/ReleaseGroupsListRepositoryImplTest.kt
@@ -36,6 +36,7 @@ import ly.david.musicsearch.data.repository.helpers.testFilter
 import ly.david.musicsearch.shared.domain.BrowseMethod
 import ly.david.musicsearch.shared.domain.ListFilters
 import ly.david.musicsearch.shared.domain.artist.ArtistCreditUiModel
+import ly.david.musicsearch.shared.domain.coroutine.CoroutineDispatchers
 import ly.david.musicsearch.shared.domain.details.ReleaseGroupDetailsModel
 import ly.david.musicsearch.shared.domain.history.DetailsMetadataDao
 import ly.david.musicsearch.shared.domain.listitem.CollectionListItemModel
@@ -63,9 +64,10 @@ class ReleaseGroupsListRepositoryImplTest :
     override val browseRemoteMetadataDao: BrowseRemoteMetadataDao by inject()
     override val artistDao: ArtistDao by inject()
     override val areaDao: AreaDao by inject()
+    override val aliasDao: AliasDao by inject()
+    override val coroutineDispatchers: CoroutineDispatchers by inject()
     private val collectionDao: CollectionDao by inject()
     private val collectionEntityDao: CollectionEntityDao by inject()
-    private val aliasDao: AliasDao by inject()
 
     private val collectionId = "950cea33-433e-497f-93bb-a05a393a2c02"
 

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/series/SeriesRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/series/SeriesRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package ly.david.musicsearch.data.repository.series
 import kotlinx.coroutines.test.runTest
 import ly.david.data.test.KoinTestRule
 import ly.david.data.test.api.FakeLookupApi
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
 import ly.david.musicsearch.data.database.dao.SeriesDao
@@ -34,6 +35,7 @@ class SeriesRepositoryImplTest : KoinTest {
     private val detailsMetadataDao: DetailsMetadataDao by inject()
     private val relationDao: RelationDao by inject()
     private val seriesDao: SeriesDao by inject()
+    private val aliasDao: AliasDao by inject()
 
     private fun createRelationRepository(
         musicBrainzModel: SeriesMusicBrainzNetworkModel,
@@ -61,6 +63,7 @@ class SeriesRepositoryImplTest : KoinTest {
         return SeriesRepositoryImpl(
             seriesDao = seriesDao,
             relationRepository = relationRepository,
+            aliasDao = aliasDao,
             lookupApi = object : FakeLookupApi() {
                 override suspend fun lookupSeries(
                     seriesId: String,

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/work/WorkRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/work/WorkRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package ly.david.musicsearch.data.repository.work
 
 import kotlinx.coroutines.test.runTest
 import ly.david.data.test.KoinTestRule
+import ly.david.musicsearch.data.database.dao.AliasDao
 import ly.david.musicsearch.data.database.dao.RelationDao
 import ly.david.musicsearch.data.database.dao.RelationsMetadataDao
 import ly.david.musicsearch.data.database.dao.WorkAttributeDao
@@ -35,6 +36,7 @@ class WorkRepositoryImplTest : KoinTest, TestWorkRepository {
     override val relationDao: RelationDao by inject()
     override val workDao: WorkDao by inject()
     override val workAttributeDao: WorkAttributeDao by inject()
+    override val aliasDao: AliasDao by inject()
 
     @Test
     fun `lookup is cached, and force refresh invalidates cache`() = runTest {

--- a/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/work/WorksListRepositoryImplTest.kt
+++ b/data/repository/src/jvmTest/kotlin/ly/david/musicsearch/data/repository/work/WorksListRepositoryImplTest.kt
@@ -54,10 +54,10 @@ class WorksListRepositoryImplTest : KoinTest, TestWorkRepository {
     override val relationsMetadataDao: RelationsMetadataDao by inject()
     override val detailsMetadataDao: DetailsMetadataDao by inject()
     override val relationDao: RelationDao by inject()
+    override val aliasDao: AliasDao by inject()
     private val collectionDao: CollectionDao by inject()
     private val browseRemoteMetadataDao: BrowseRemoteMetadataDao by inject()
     private val collectionEntityDao: CollectionEntityDao by inject()
-    private val aliasDao: AliasDao by inject()
 
     private val collectionId = "950cea33-433e-497f-93bb-a05a393a2c02"
 


### PR DESCRIPTION
now we cascade delete, and lookups will insert aliases

https://github.com/lydavid/MusicSearch/issues/1659